### PR TITLE
feat: enhance Plex metadata sync functionality

### DIFF
--- a/config/playbook.sample.yaml
+++ b/config/playbook.sample.yaml
@@ -116,15 +116,17 @@ settings:
   # as the source of truth. Episodes are always updated; shows/seasons update on
   # first run or when the metadata fingerprint changes (or when force is true).
   plex_metadata_sync:
-    enabled: false                   # Set true to run pre-sync; or PLEX_SYNC_ENABLED=true
+    enabled: false                   # Set true to enable; or PLEX_SYNC_ENABLED=true
     url: ${PLEX_URL:-http://plex:32400}
     token: ${PLEX_TOKEN:-}
-    library_id: ${PLEX_LIBRARY_ID:-} # Optional: prefer ID when known
+    library_id: ${PLEX_LIBRARY_ID:-} # Optional: prefer ID for faster lookup
     library_name: ${PLEX_LIBRARY_NAME:-TV Shows} # Used when library_id is not set
-    timeout: ${PLEX_TIMEOUT:-15}     # Seconds
-    force: ${PLEX_FORCE:-false}      # Force show/season updates even if unchanged
+    timeout: ${PLEX_TIMEOUT:-15}     # HTTP timeout in seconds
+    force: ${PLEX_FORCE:-false}      # Force all updates even if unchanged
     dry_run: ${PLEX_SYNC_DRY_RUN:-false} # Log only, no Plex writes
-    sports: []                       # Optional list of sport ids to limit syncing; env PLEX_SPORTS=foo,bar
+    sports: []                       # Limit to specific sport ids; env PLEX_SPORTS=foo,bar
+    # Features: automatic retry with backoff, rate limiting, field locking,
+    # fingerprint-based change detection for shows/seasons/episodes
 
   ####################################################################
   # DEFAULT DESTINATION TEMPLATES

--- a/src/playbook/config.py
+++ b/src/playbook/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 from .pattern_templates import expand_regex_with_tokens, load_builtin_pattern_sets
-from .utils import load_yaml_file
+from .utils import load_yaml_file, validate_url
 
 
 @dataclass(slots=True)
@@ -419,9 +419,18 @@ def _build_plex_sync_settings(data: Dict[str, Any]) -> PlexSyncSettings:
         text = str(value).strip()
         return text or None
 
+    url = _clean_str(data.get("url"))
+    enabled = bool(data.get("enabled", False))
+
+    # Validate URL format if provided and enabled
+    if url and enabled and not validate_url(url):
+        raise ValueError(
+            f"'plex_metadata_sync.url' must be a valid http/https URL, got: {url}"
+        )
+
     return PlexSyncSettings(
-        enabled=bool(data.get("enabled", False)),
-        url=_clean_str(data.get("url")),
+        enabled=enabled,
+        url=url,
         token=_clean_str(data.get("token")),
         library_id=_clean_str(data.get("library_id")),
         library_name=_clean_str(data.get("library_name")),

--- a/src/playbook/plex_client.py
+++ b/src/playbook/plex_client.py
@@ -1,18 +1,39 @@
 from __future__ import annotations
 
-import json
 import logging
-from dataclasses import dataclass
+import re
+import time
+from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 LOGGER = logging.getLogger(__name__)
+
+# Plex metadata type codes from openapi.json
+PLEX_TYPE_SHOW = 2
+PLEX_TYPE_SEASON = 3
+PLEX_TYPE_EPISODE = 4
+
+# Default retry configuration
+DEFAULT_RETRIES = 3
+DEFAULT_BACKOFF_FACTOR = 0.5
+RETRY_STATUS_CODES = frozenset({500, 502, 503, 504, 429})
 
 
 class PlexApiError(RuntimeError):
     """Raised when Plex API requests fail."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class PlexRateLimitError(PlexApiError):
+    """Raised when Plex returns 429 Too Many Requests."""
 
 
 def _build_url(base_url: str, path: str) -> str:
@@ -20,12 +41,32 @@ def _build_url(base_url: str, path: str) -> str:
     return urljoin(normalized, path.lstrip("/"))
 
 
+def _sanitize_url_for_logging(url: str) -> str:
+    """Remove sensitive query parameters from URL for safe logging."""
+    # Remove X-Plex-Token from URL if present (shouldn't be, but defensive)
+    return re.sub(r"[?&]X-Plex-Token=[^&]*", "", url)
+
+
 def _parse_json_response(response: requests.Response) -> Dict[str, Any]:
     try:
         return response.json()
-    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+    except ValueError as exc:  # pragma: no cover - defensive
         snippet = response.text[:500]
-        raise PlexApiError(f"Failed to parse Plex response as JSON ({response.status_code}): {snippet}") from exc
+        raise PlexApiError(
+            f"Failed to parse Plex response as JSON ({response.status_code}): {snippet}",
+            status_code=response.status_code,
+        ) from exc
+
+
+def validate_plex_url(url: Optional[str]) -> bool:
+    """Validate that URL is a valid http/https URL."""
+    if not url:
+        return False
+    try:
+        parsed = urlparse(url)
+        return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+    except Exception:  # noqa: BLE001 - defensive
+        return False
 
 
 @dataclass(slots=True)
@@ -35,8 +76,59 @@ class PlexLibrary:
     type: Optional[str]
 
 
+@dataclass(slots=True)
+class PlexSyncStats:
+    """Track statistics for a Plex sync operation."""
+
+    shows_updated: int = 0
+    shows_skipped: int = 0
+    seasons_updated: int = 0
+    seasons_skipped: int = 0
+    seasons_not_found: int = 0
+    episodes_updated: int = 0
+    episodes_skipped: int = 0
+    episodes_not_found: int = 0
+    assets_updated: int = 0
+    assets_failed: int = 0
+    api_calls: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    def has_activity(self) -> bool:
+        return any(
+            (
+                self.shows_updated,
+                self.seasons_updated,
+                self.episodes_updated,
+                self.assets_updated,
+                self.errors,
+            )
+        )
+
+    def summary(self) -> Dict[str, Any]:
+        return {
+            "shows": {"updated": self.shows_updated, "skipped": self.shows_skipped},
+            "seasons": {
+                "updated": self.seasons_updated,
+                "skipped": self.seasons_skipped,
+                "not_found": self.seasons_not_found,
+            },
+            "episodes": {
+                "updated": self.episodes_updated,
+                "skipped": self.episodes_skipped,
+                "not_found": self.episodes_not_found,
+            },
+            "assets": {"updated": self.assets_updated, "failed": self.assets_failed},
+            "api_calls": self.api_calls,
+            "errors": len(self.errors),
+        }
+
+
 class PlexClient:
-    """Thin wrapper around Plex HTTP endpoints defined in openapi.json."""
+    """Thin wrapper around Plex HTTP endpoints defined in openapi.json.
+
+    Token is passed via X-Plex-Token header (not query params) for security.
+    Includes automatic retries with exponential backoff for transient failures.
+    """
 
     def __init__(
         self,
@@ -45,11 +137,40 @@ class PlexClient:
         *,
         timeout: float = 15.0,
         session: Optional[requests.Session] = None,
+        max_retries: int = DEFAULT_RETRIES,
+        backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+        rate_limit_delay: float = 0.0,
     ) -> None:
+        if not validate_plex_url(base_url):
+            raise PlexApiError(f"Invalid Plex URL: {base_url}")
+
         self.base_url = base_url.rstrip("/")
         self.token = token
         self.timeout = timeout
+        self.rate_limit_delay = rate_limit_delay
+        self._last_request_time: float = 0.0
+
         self.session = session or requests.Session()
+        if session is None:
+            # Configure retry strategy
+            retry_strategy = Retry(
+                total=max_retries,
+                backoff_factor=backoff_factor,
+                status_forcelist=list(RETRY_STATUS_CODES),
+                allowed_methods=["GET", "PUT", "POST", "DELETE"],
+                raise_on_status=False,
+            )
+            adapter = HTTPAdapter(max_retries=retry_strategy, pool_maxsize=10)
+            self.session.mount("http://", adapter)
+            self.session.mount("https://", adapter)
+
+    def _apply_rate_limit(self) -> None:
+        """Apply rate limiting delay between requests if configured."""
+        if self.rate_limit_delay <= 0:
+            return
+        elapsed = time.monotonic() - self._last_request_time
+        if elapsed < self.rate_limit_delay:
+            time.sleep(self.rate_limit_delay - elapsed)
 
     def _request(
         self,
@@ -61,30 +182,52 @@ class PlexClient:
         allow_error: bool = False,
         **kwargs: Any,
     ) -> requests.Response:
+        self._apply_rate_limit()
+
         url = _build_url(self.base_url, path)
         merged_params = dict(params or {})
-        merged_params["X-Plex-Token"] = self.token
-        merged_headers = {"Accept": "application/json"}
+        # Token goes in header, NOT query params (security)
+        merged_headers = {
+            "Accept": "application/json",
+            "X-Plex-Token": self.token,
+        }
         if headers:
             merged_headers.update(headers)
 
-        LOGGER.debug("Plex %s %s", method.upper(), url)
-        response = self.session.request(
-            method,
-            url,
-            params=merged_params,
-            headers=merged_headers,
-            timeout=self.timeout,
-            **kwargs,
-        )
+        # Log sanitized URL only
+        LOGGER.debug("Plex %s %s", method.upper(), _sanitize_url_for_logging(url))
+
+        try:
+            response = self.session.request(
+                method,
+                url,
+                params=merged_params,
+                headers=merged_headers,
+                timeout=self.timeout,
+                **kwargs,
+            )
+        except requests.RequestException as exc:
+            raise PlexApiError(f"Plex request failed: {exc}") from exc
+        finally:
+            self._last_request_time = time.monotonic()
+
+        if response.status_code == 429:
+            raise PlexRateLimitError(
+                "Plex rate limit exceeded (429)",
+                status_code=429,
+            )
 
         if not allow_error and response.status_code >= 400:
             snippet = response.text[:200]
-            raise PlexApiError(f"Plex request failed ({response.status_code}): {snippet}")
+            raise PlexApiError(
+                f"Plex request failed ({response.status_code}): {snippet}",
+                status_code=response.status_code,
+            )
 
         return response
 
-    def list_libraries(self) -> List[PlexLibrary]:
+    def list_libraries(self, *, type_filter: Optional[str] = None) -> List[PlexLibrary]:
+        """List all Plex libraries, optionally filtered by type."""
         response = self._request("GET", "/library/sections")
         payload = _parse_json_response(response)
         container = payload.get("MediaContainer", {})
@@ -93,26 +236,55 @@ class PlexClient:
         for entry in directories:
             key = entry.get("key")
             title = entry.get("title")
+            lib_type = entry.get("type")
             if key is None or title is None:
                 continue
-            libraries.append(PlexLibrary(key=str(key), title=str(title), type=entry.get("type")))
+            if type_filter and lib_type != type_filter:
+                continue
+            libraries.append(PlexLibrary(key=str(key), title=str(title), type=lib_type))
         return libraries
 
-    def find_library(self, *, library_id: Optional[str], library_name: Optional[str]) -> str:
+    def find_library(
+        self,
+        *,
+        library_id: Optional[str],
+        library_name: Optional[str],
+        require_type: Optional[str] = "show",
+    ) -> str:
+        """Find a library by ID or name, optionally requiring a specific type."""
         if library_id:
+            # If ID provided, validate it exists and optionally check type
+            if require_type:
+                libraries = self.list_libraries(type_filter=require_type)
+                for lib in libraries:
+                    if lib.key == str(library_id):
+                        return lib.key
+                # ID not found in filtered list; check if it exists at all
+                all_libs = self.list_libraries()
+                for lib in all_libs:
+                    if lib.key == str(library_id):
+                        raise PlexApiError(
+                            f"Library '{library_id}' exists but is type '{lib.type}', not '{require_type}'"
+                        )
+                raise PlexApiError(f"Library with ID '{library_id}' not found")
             return str(library_id)
-        libraries = self.list_libraries()
+
+        libraries = self.list_libraries(type_filter=require_type)
         if not library_name:
             raise PlexApiError("Library id or name is required to target Plex")
+
         for library in libraries:
             if library.title.lower() == library_name.lower():
                 return library.key
+
         available = ", ".join(lib.title for lib in libraries) or "(none)"
-        raise PlexApiError(f"Plex library '{library_name}' not found (available: {available})")
+        type_msg = f" of type '{require_type}'" if require_type else ""
+        raise PlexApiError(f"Plex library '{library_name}'{type_msg} not found (available: {available})")
 
     def search_show(self, library_id: str, title: str) -> Optional[Dict[str, Any]]:
+        """Search for a TV show by title in a library."""
         params = {
-            "type": 2,  # show
+            "type": PLEX_TYPE_SHOW,
             "title": title,
         }
         response = self._request("GET", f"/library/sections/{library_id}/all", params=params)
@@ -120,24 +292,88 @@ class PlexClient:
         metadata_entries: Iterable[Dict[str, Any]] = (
             payload.get("MediaContainer", {}).get("Metadata") or []
         )
+        # Prefer exact match
         for entry in metadata_entries:
             if str(entry.get("title", "")).lower() == title.lower():
                 return entry
+        # Fall back to first result
         return next(iter(metadata_entries), None)
 
+    def get_metadata(self, rating_key: str) -> Optional[Dict[str, Any]]:
+        """Get full metadata for an item by rating key."""
+        response = self._request("GET", f"/library/metadata/{rating_key}", allow_error=True)
+        if response.status_code == 404:
+            return None
+        if response.status_code >= 400:
+            raise PlexApiError(
+                f"Failed to get metadata for {rating_key}: {response.status_code}",
+                status_code=response.status_code,
+            )
+        payload = _parse_json_response(response)
+        metadata_list = payload.get("MediaContainer", {}).get("Metadata") or []
+        return metadata_list[0] if metadata_list else None
+
     def list_children(self, rating_key: str) -> List[Dict[str, Any]]:
+        """List children of an item (e.g., seasons of a show, episodes of a season)."""
         response = self._request("GET", f"/library/metadata/{rating_key}/children")
         payload = _parse_json_response(response)
         return list(payload.get("MediaContainer", {}).get("Metadata") or [])
 
-    def update_metadata(self, rating_key: str, params: Dict[str, Any]) -> None:
-        clean_params = {key: value for key, value in params.items() if value is not None}
-        if not clean_params:
-            return
-        self._request("PUT", f"/library/metadata/{rating_key}", params=clean_params)
+    def update_metadata(
+        self,
+        rating_key: str,
+        params: Dict[str, Any],
+        *,
+        lock_fields: bool = True,
+    ) -> bool:
+        """Update metadata fields for an item.
 
-    def set_asset(self, rating_key: str, element: str, url: str) -> None:
+        Args:
+            rating_key: The Plex rating key of the item.
+            params: Dict of field names to values. Use Plex field names (title, sortTitle, etc.)
+            lock_fields: If True, lock fields to prevent Plex agents from overwriting.
+
+        Returns:
+            True if update was performed, False if nothing to update.
+        """
+        clean_params: Dict[str, Any] = {}
+        for key, value in params.items():
+            if value is None:
+                continue
+            if key == "type":
+                clean_params[key] = value
+                continue
+            # Add the field value
+            clean_params[f"{key}.value"] = value
+            # Lock the field to prevent agent overwrites
+            if lock_fields:
+                clean_params[f"{key}.locked"] = 1
+
+        if not clean_params or (len(clean_params) == 1 and "type" in clean_params):
+            return False
+
+        self._request("PUT", f"/library/metadata/{rating_key}", params=clean_params)
+        return True
+
+    def set_asset(self, rating_key: str, element: str, url: str) -> bool:
+        """Set an artwork asset (poster/thumb, art/background) from a URL.
+
+        Args:
+            rating_key: The Plex rating key of the item.
+            element: Asset type - use 'thumb' for poster, 'art' for background.
+            url: URL to the image.
+
+        Returns:
+            True if successful.
+        """
+        valid_elements = {"thumb", "art", "banner", "clearLogo", "theme"}
+        if element not in valid_elements:
+            raise PlexApiError(f"Invalid asset element '{element}'; valid: {valid_elements}")
+
         params = {"url": url}
         self._request("PUT", f"/library/metadata/{rating_key}/{element}", params=params)
+        return True
 
-
+    def refresh_metadata(self, rating_key: str) -> None:
+        """Trigger a metadata refresh for an item."""
+        self._request("PUT", f"/library/metadata/{rating_key}/refresh")

--- a/src/playbook/plex_metadata_sync.py
+++ b/src/playbook/plex_metadata_sync.py
@@ -1,86 +1,59 @@
+"""Plex metadata sync - push metadata from remote YAML to Plex.
+
+This module syncs show/season/episode metadata (titles, sort titles, summaries,
+dates, posters, backgrounds) from the remote metadata YAML files to Plex.
+
+Shows and seasons are updated on first run or when metadata changes.
+Episodes are updated when their content changes (fingerprint-based detection).
+"""
+
 from __future__ import annotations
 
-import argparse
 import datetime as dt
 import logging
-import sys
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urljoin
 
-from .config import AppConfig, SportConfig, load_config
-from .metadata import MetadataFingerprintStore, compute_show_fingerprint, load_show
+from .config import AppConfig, PlexSyncSettings, SportConfig
+from .metadata import (
+    MetadataChangeResult,
+    MetadataFingerprintStore,
+    ShowFingerprint,
+    compute_show_fingerprint,
+    load_show,
+)
 from .models import Episode, Season, Show
-from .plex_client import PlexApiError, PlexClient
+from .plex_client import (
+    PLEX_TYPE_EPISODE,
+    PLEX_TYPE_SEASON,
+    PLEX_TYPE_SHOW,
+    PlexApiError,
+    PlexClient,
+    PlexSyncStats,
+)
+from .utils import env_bool, env_list
 
 LOGGER = logging.getLogger(__name__)
-
-METADATA_TYPE = {
-    "show": 2,
-    "season": 3,
-    "episode": 4,
-}
 
 
 @dataclass(slots=True)
 class MappedMetadata:
+    """Metadata fields mapped for Plex API update."""
+
     title: Optional[str]
     sort_title: Optional[str]
     original_title: Optional[str]
     originally_available_at: Optional[str]
     summary: Optional[str]
-    poster: Optional[str]
-    background: Optional[str]
-
-
-def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Sync Plex metadata from remote YAML before Kometa runs.")
-    parser.add_argument(
-        "--config",
-        type=Path,
-        default=Path("/config/playbook.yaml"),
-        help="Path to playbook YAML config (defaults to /config/playbook.yaml)",
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Enable debug logging",
-    )
-    return parser.parse_args(argv)
-
-
-def _configure_logging(verbose: bool) -> None:
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s | %(levelname)-8s | %(name)s\n%(message)s\n",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
-
-def _env_bool(name: str) -> Optional[bool]:
-    value = os.getenv(name)
-    if value is None:
-        return None
-    lowered = value.strip().lower()
-    if lowered in {"1", "true", "yes", "on"}:
-        return True
-    if lowered in {"0", "false", "no", "off"}:
-        return False
-    return None
-
-
-def _env_list(name: str) -> Optional[List[str]]:
-    raw = os.getenv(name)
-    if raw is None:
-        return None
-    parts = [part.strip() for part in raw.split(",") if part.strip()]
-    return parts or []
+    poster_url: Optional[str]
+    background_url: Optional[str]
 
 
 def _as_int(value: object) -> Optional[int]:
+    """Safely convert value to int."""
     if value is None:
         return None
     try:
@@ -89,7 +62,8 @@ def _as_int(value: object) -> Optional[int]:
         return None
 
 
-def _first(metadata: Dict[str, object], keys: Iterable[str]) -> Optional[str]:
+def _first(metadata: Dict[str, object], keys: tuple[str, ...]) -> Optional[str]:
+    """Get first non-empty value from metadata dict for given keys."""
     for key in keys:
         value = metadata.get(key)
         if value:
@@ -98,6 +72,7 @@ def _first(metadata: Dict[str, object], keys: Iterable[str]) -> Optional[str]:
 
 
 def _parse_date(value: object) -> Optional[str]:
+    """Parse date to ISO format string."""
     if value is None:
         return None
     if isinstance(value, dt.datetime):
@@ -110,7 +85,8 @@ def _parse_date(value: object) -> Optional[str]:
         return None
 
 
-def _resolve_asset(base_url: str, value: Optional[str]) -> Optional[str]:
+def _resolve_asset_url(base_url: str, value: Optional[str]) -> Optional[str]:
+    """Resolve asset path to full URL."""
     if not value:
         return None
     if value.startswith(("http://", "https://")):
@@ -119,6 +95,7 @@ def _resolve_asset(base_url: str, value: Optional[str]) -> Optional[str]:
 
 
 def _map_show_metadata(show: Show, base_url: str) -> MappedMetadata:
+    """Extract Plex-compatible metadata from Show object."""
     meta = show.metadata or {}
     return MappedMetadata(
         title=show.title or meta.get("title"),
@@ -128,12 +105,13 @@ def _map_show_metadata(show: Show, base_url: str) -> MappedMetadata:
             _first(meta, ("originally_available", "originally_available_at"))
         ),
         summary=show.summary or meta.get("summary"),
-        poster=_resolve_asset(base_url, _first(meta, ("poster", "thumb", "cover"))),
-        background=_resolve_asset(base_url, _first(meta, ("background", "art", "fanart"))),
+        poster_url=_resolve_asset_url(base_url, _first(meta, ("poster", "thumb", "cover"))),
+        background_url=_resolve_asset_url(base_url, _first(meta, ("background", "art", "fanart"))),
     )
 
 
 def _map_season_metadata(season: Season, base_url: str) -> MappedMetadata:
+    """Extract Plex-compatible metadata from Season object."""
     meta = season.metadata or {}
     return MappedMetadata(
         title=season.title or meta.get("title"),
@@ -143,30 +121,58 @@ def _map_season_metadata(season: Season, base_url: str) -> MappedMetadata:
             _first(meta, ("originally_available", "originally_available_at"))
         ),
         summary=season.summary or meta.get("summary"),
-        poster=_resolve_asset(base_url, _first(meta, ("poster", "thumb", "cover"))),
-        background=_resolve_asset(base_url, _first(meta, ("background", "art", "fanart"))),
+        poster_url=_resolve_asset_url(base_url, _first(meta, ("poster", "thumb", "cover"))),
+        background_url=_resolve_asset_url(base_url, _first(meta, ("background", "art", "fanart"))),
     )
 
 
 def _map_episode_metadata(episode: Episode, base_url: str) -> MappedMetadata:
+    """Extract Plex-compatible metadata from Episode object."""
     meta = episode.metadata or {}
     return MappedMetadata(
         title=episode.title or meta.get("title"),
         sort_title=_first(meta, ("sort_title", "sortTitle", "slug")),
         original_title=_first(meta, ("original_title", "originalTitle")),
         originally_available_at=_parse_date(
-            _first(meta, ("originally_available", "originally_available_at")) or episode.originally_available
+            _first(meta, ("originally_available", "originally_available_at"))
+            or episode.originally_available
         ),
         summary=episode.summary or meta.get("summary"),
-        poster=_resolve_asset(base_url, _first(meta, ("poster", "thumb", "cover"))),
-        background=_resolve_asset(base_url, _first(meta, ("background", "art", "fanart"))),
+        poster_url=_resolve_asset_url(base_url, _first(meta, ("poster", "thumb", "cover"))),
+        background_url=_resolve_asset_url(base_url, _first(meta, ("background", "art", "fanart"))),
     )
 
 
+def _season_identifier(season: Season) -> str:
+    """Generate a stable identifier for a season."""
+    key = getattr(season, "key", None)
+    if key:
+        return str(key)
+    if season.display_number is not None:
+        return f"display:{season.display_number}"
+    return f"index:{season.index}"
+
+
+def _episode_identifier(episode: Episode) -> str:
+    """Generate a stable identifier for an episode."""
+    metadata = episode.metadata or {}
+    for field in ("id", "guid", "episode_id", "uuid"):
+        value = metadata.get(field)
+        if value:
+            return f"{field}:{value}"
+    if episode.display_number is not None:
+        return f"display:{episode.display_number}"
+    if episode.title:
+        return f"title:{episode.title}"
+    return f"index:{episode.index}"
+
+
 def _match_season_key(plex_seasons: List[Dict[str, object]], season: Season) -> Optional[str]:
+    """Find the Plex rating key for a season by matching index or title."""
     target_numbers = {season.display_number, season.index}
     target_numbers = {num for num in target_numbers if num is not None}
     target_title = (season.title or "").lower()
+
     for entry in plex_seasons:
         rating_key = entry.get("ratingKey")
         if not rating_key:
@@ -184,9 +190,11 @@ def _match_season_key(plex_seasons: List[Dict[str, object]], season: Season) -> 
 
 
 def _match_episode_key(plex_episodes: List[Dict[str, object]], episode: Episode) -> Optional[str]:
+    """Find the Plex rating key for an episode by matching index or title."""
     target_numbers = {episode.display_number, episode.index}
     target_numbers = {num for num in target_numbers if num is not None}
     target_title = (episode.title or "").lower()
+
     for entry in plex_episodes:
         rating_key = entry.get("ratingKey")
         if not rating_key:
@@ -210,7 +218,12 @@ def _apply_metadata(
     type_code: int,
     label: str,
     dry_run: bool,
-) -> None:
+    stats: PlexSyncStats,
+) -> bool:
+    """Apply metadata to a Plex item.
+
+    Returns True if any updates were made.
+    """
     fields = {
         "type": type_code,
         "title": mapped.title,
@@ -219,191 +232,486 @@ def _apply_metadata(
         "originallyAvailableAt": mapped.originally_available_at,
         "summary": mapped.summary,
     }
-    fields = {key: value for key, value in fields.items() if value}
-    if fields:
+    # Remove None/empty values (except type)
+    fields = {key: value for key, value in fields.items() if value or key == "type"}
+
+    updated = False
+
+    if len(fields) > 1:  # More than just 'type'
         if dry_run:
             LOGGER.info("Dry-run: would update %s %s with %s", label, rating_key, fields)
         else:
-            client.update_metadata(rating_key, fields)
-            LOGGER.info("Updated %s metadata (%s)", label, rating_key)
-    for asset_field, element in (("poster", "poster"), ("background", "art")):
-        asset_url = getattr(mapped, asset_field)
+            try:
+                if client.update_metadata(rating_key, fields, lock_fields=True):
+                    LOGGER.info("Updated %s metadata (%s)", label, rating_key)
+                    updated = True
+                stats.api_calls += 1
+            except PlexApiError as exc:
+                LOGGER.error("Failed to update %s %s: %s", label, rating_key, exc)
+                stats.errors.append(f"{label} {rating_key}: {exc}")
+
+    # Handle assets: poster -> 'thumb', background -> 'art'
+    asset_mappings = [
+        ("poster_url", "thumb", "poster"),
+        ("background_url", "art", "background"),
+    ]
+    for attr, element, display_name in asset_mappings:
+        asset_url = getattr(mapped, attr)
         if not asset_url:
             continue
         if dry_run:
-            LOGGER.info("Dry-run: would set %s %s %s to %s", label, rating_key, element, asset_url)
+            LOGGER.info("Dry-run: would set %s %s %s to %s", label, rating_key, display_name, asset_url)
         else:
-            client.set_asset(rating_key, element, asset_url)
-            LOGGER.info("Updated %s %s asset (%s)", label, element, rating_key)
+            try:
+                client.set_asset(rating_key, element, asset_url)
+                LOGGER.debug("Set %s %s for %s (%s)", label, display_name, rating_key, asset_url[:50])
+                stats.assets_updated += 1
+                stats.api_calls += 1
+                updated = True
+            except PlexApiError as exc:
+                LOGGER.error("Failed to set %s %s for %s: %s", label, display_name, rating_key, exc)
+                stats.assets_failed += 1
+                stats.errors.append(f"{label} {rating_key} {display_name}: {exc}")
+
+    return updated
 
 
-def _load_show(config: AppConfig, sport: SportConfig) -> Show:
-    return load_show(config.settings, sport.metadata)
+class PlexMetadataSync:
+    """Syncs metadata from remote YAML to Plex.
 
+    Uses fingerprint-based change detection to minimize unnecessary updates.
+    Shows/seasons update on first run or when metadata changes.
+    Episodes update when their specific content changes.
+    """
 
-def _sync_single_sport(
-    *,
-    client: PlexClient,
-    library_id: str,
-    config: AppConfig,
-    sport: SportConfig,
-    fingerprint_store: MetadataFingerprintStore,
-    force: bool,
-    dry_run: bool,
-) -> None:
-    show = _load_show(config, sport)
-    previous_fingerprint = fingerprint_store.get(sport.id)
-    fingerprint = compute_show_fingerprint(show, sport.metadata)
-    change = fingerprint_store.update(sport.id, fingerprint)
-    is_first_sync = previous_fingerprint is None
+    def __init__(
+        self,
+        config: AppConfig,
+        *,
+        plex_url: Optional[str] = None,
+        plex_token: Optional[str] = None,
+        library_id: Optional[str] = None,
+        library_name: Optional[str] = None,
+        force: bool = False,
+        dry_run: bool = False,
+        timeout: float = 15.0,
+        rate_limit_delay: float = 0.1,
+        sports_filter: Optional[List[str]] = None,
+    ) -> None:
+        self.config = config
+        self.dry_run = dry_run
+        self.force = force
+        self.sports_filter = sports_filter
 
-    should_update_show = force or change.updated
-    plex_show = client.search_show(library_id, show.title)
-    if plex_show is None:
-        LOGGER.error("Plex show not found for '%s' in library %s", show.title, library_id)
-        return
-    show_rating = str(plex_show.get("ratingKey"))
-    if not show_rating:
-        LOGGER.error("Plex show ratingKey missing for '%s'", show.title)
-        return
+        # Resolve settings from config + env vars + explicit params
+        plex_cfg = config.settings.plex_sync
 
-    base_url = sport.metadata.url
-    mapped_show = _map_show_metadata(show, base_url)
-    if should_update_show:
-        _apply_metadata(client, show_rating, mapped_show, type_code=METADATA_TYPE["show"], label="show", dry_run=dry_run)
+        self.plex_url = plex_url or os.getenv("PLEX_URL") or plex_cfg.url
+        self.plex_token = plex_token or os.getenv("PLEX_TOKEN") or plex_cfg.token
+        self.library_id = library_id or os.getenv("PLEX_LIBRARY_ID") or plex_cfg.library_id
+        self.library_name = library_name or os.getenv("PLEX_LIBRARY_NAME") or plex_cfg.library_name
 
-    plex_seasons = client.list_children(show_rating)
-    seasons_to_update: List[Season] = []
-    if force or change.invalidate_all or is_first_sync:
-        seasons_to_update = list(show.seasons)
-    elif change.changed_seasons:
-        seasons_to_update = [season for season in show.seasons if str(season.key) in change.changed_seasons]
+        env_timeout = os.getenv("PLEX_TIMEOUT")
+        self.timeout = float(env_timeout) if env_timeout else (timeout or plex_cfg.timeout)
+        self.rate_limit_delay = rate_limit_delay
 
-    for season in seasons_to_update:
-        season_rating = _match_season_key(plex_seasons, season)
-        if not season_rating:
-            LOGGER.warning("Season not found in Plex for %s: %s", show.title, season.title)
-            continue
-        mapped_season = _map_season_metadata(season, base_url)
-        _apply_metadata(
-            client,
-            season_rating,
-            mapped_season,
-            type_code=METADATA_TYPE["season"],
-            label=f"season '{season.title}'",
-            dry_run=dry_run,
+        self._client: Optional[PlexClient] = None
+        self._library_id_resolved: Optional[str] = None
+        self._fingerprint_store: Optional[MetadataFingerprintStore] = None
+
+    @property
+    def client(self) -> PlexClient:
+        """Lazily create the Plex client."""
+        if self._client is None:
+            if not self.plex_url or not self.plex_token:
+                raise PlexApiError("Plex URL and token are required")
+            self._client = PlexClient(
+                self.plex_url,
+                self.plex_token,
+                timeout=self.timeout,
+                rate_limit_delay=self.rate_limit_delay,
+            )
+        return self._client
+
+    @property
+    def fingerprint_store(self) -> MetadataFingerprintStore:
+        """Lazily create the fingerprint store."""
+        if self._fingerprint_store is None:
+            self._fingerprint_store = MetadataFingerprintStore(
+                self.config.settings.cache_dir,
+                filename="plex-metadata-hashes.json",
+            )
+        return self._fingerprint_store
+
+    def resolve_library(self) -> str:
+        """Resolve and cache the target library ID."""
+        if self._library_id_resolved is None:
+            if not self.library_id and not self.library_name:
+                raise PlexApiError(
+                    "Provide a Plex library id or name "
+                    "(settings.plex_metadata_sync.library_id/library_name or env PLEX_LIBRARY_ID/PLEX_LIBRARY_NAME)"
+                )
+            self._library_id_resolved = self.client.find_library(
+                library_id=self.library_id,
+                library_name=self.library_name,
+                require_type="show",
+            )
+        return self._library_id_resolved
+
+    def sync_all(self) -> PlexSyncStats:
+        """Sync all configured sports to Plex.
+
+        Returns statistics about what was updated.
+        """
+        stats = PlexSyncStats()
+
+        try:
+            library_id = self.resolve_library()
+        except PlexApiError as exc:
+            LOGGER.error("Failed to resolve Plex library: %s", exc)
+            stats.errors.append(f"Library resolution: {exc}")
+            return stats
+
+        sports = self._get_target_sports()
+        if not sports:
+            LOGGER.info("No sports to sync")
+            return stats
+
+        LOGGER.info("Starting Plex metadata sync for %d sport(s)", len(sports))
+
+        for sport in sports:
+            try:
+                self._sync_sport(sport, library_id, stats)
+            except PlexApiError as exc:
+                LOGGER.error("Plex API error for sport %s: %s", sport.id, exc)
+                stats.errors.append(f"Sport {sport.id}: {exc}")
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.exception("Unexpected error syncing %s: %s", sport.id, exc)
+                stats.errors.append(f"Sport {sport.id}: {exc}")
+
+        self.fingerprint_store.save()
+
+        if stats.has_activity():
+            summary = stats.summary()
+            LOGGER.info(
+                "Plex sync complete: shows=%d/%d seasons=%d/%d episodes=%d/%d assets=%d errors=%d",
+                summary["shows"]["updated"],
+                summary["shows"]["skipped"],
+                summary["seasons"]["updated"],
+                summary["seasons"]["skipped"],
+                summary["episodes"]["updated"],
+                summary["episodes"]["skipped"],
+                summary["assets"]["updated"],
+                summary["errors"],
+            )
+        else:
+            LOGGER.info("Plex sync complete: no updates needed")
+
+        return stats
+
+    def _get_target_sports(self) -> List[SportConfig]:
+        """Get list of sports to sync, respecting filter."""
+        all_sports = [sport for sport in self.config.sports if sport.enabled]
+
+        if self.sports_filter:
+            filter_set = set(self.sports_filter)
+            return [sport for sport in all_sports if sport.id in filter_set]
+
+        return all_sports
+
+    def _sync_sport(
+        self,
+        sport: SportConfig,
+        library_id: str,
+        stats: PlexSyncStats,
+    ) -> None:
+        """Sync a single sport to Plex."""
+        LOGGER.info("Syncing sport: %s (%s)", sport.id, sport.name)
+
+        # Load metadata from remote YAML
+        show = load_show(self.config.settings, sport.metadata)
+
+        # Compute and compare fingerprint
+        previous_fingerprint = self.fingerprint_store.get(sport.id)
+        fingerprint = compute_show_fingerprint(show, sport.metadata)
+        change = self.fingerprint_store.update(sport.id, fingerprint)
+        is_first_sync = previous_fingerprint is None
+
+        # Find show in Plex
+        plex_show = self.client.search_show(library_id, show.title)
+        stats.api_calls += 1
+
+        if plex_show is None:
+            LOGGER.warning("Show not found in Plex: '%s' (library %s)", show.title, library_id)
+            stats.errors.append(f"Show not found: {show.title}")
+            return
+
+        show_rating = str(plex_show.get("ratingKey"))
+        if not show_rating:
+            LOGGER.error("Show ratingKey missing for '%s'", show.title)
+            stats.errors.append(f"Missing ratingKey: {show.title}")
+            return
+
+        base_url = sport.metadata.url
+
+        # Sync show metadata
+        self._sync_show(
+            show=show,
+            show_rating=show_rating,
+            base_url=base_url,
+            change=change,
+            is_first_sync=is_first_sync,
+            stats=stats,
         )
 
-    for season in show.seasons:
-        season_rating = _match_season_key(plex_seasons, season)
-        if not season_rating:
-            LOGGER.warning("Skipping episodes; season not found in Plex for %s: %s", show.title, season.title)
-            continue
-        plex_episodes = client.list_children(season_rating)
-        for episode in season.episodes:
-            episode_rating = _match_episode_key(plex_episodes, episode)
-            if not episode_rating:
-                LOGGER.warning(
-                    "Episode not found in Plex for %s / %s: %s",
-                    show.title,
-                    season.title,
-                    episode.title,
-                )
+        # Sync seasons and episodes
+        self._sync_seasons_and_episodes(
+            show=show,
+            show_rating=show_rating,
+            base_url=base_url,
+            fingerprint=fingerprint,
+            previous_fingerprint=previous_fingerprint,
+            change=change,
+            is_first_sync=is_first_sync,
+            stats=stats,
+        )
+
+    def _sync_show(
+        self,
+        *,
+        show: Show,
+        show_rating: str,
+        base_url: str,
+        change: MetadataChangeResult,
+        is_first_sync: bool,
+        stats: PlexSyncStats,
+    ) -> None:
+        """Sync show-level metadata."""
+        should_update = self.force or change.updated or is_first_sync
+
+        if not should_update:
+            LOGGER.debug("Show '%s' unchanged, skipping", show.title)
+            stats.shows_skipped += 1
+            return
+
+        mapped = _map_show_metadata(show, base_url)
+        if _apply_metadata(
+            self.client,
+            show_rating,
+            mapped,
+            type_code=PLEX_TYPE_SHOW,
+            label=f"show '{show.title}'",
+            dry_run=self.dry_run,
+            stats=stats,
+        ):
+            stats.shows_updated += 1
+        else:
+            stats.shows_skipped += 1
+
+    def _sync_seasons_and_episodes(
+        self,
+        *,
+        show: Show,
+        show_rating: str,
+        base_url: str,
+        fingerprint: ShowFingerprint,
+        previous_fingerprint: Optional[ShowFingerprint],
+        change: MetadataChangeResult,
+        is_first_sync: bool,
+        stats: PlexSyncStats,
+    ) -> None:
+        """Sync season and episode metadata."""
+        # Fetch Plex seasons once
+        plex_seasons = self.client.list_children(show_rating)
+        stats.api_calls += 1
+
+        # Build season rating key cache
+        season_rating_cache: Dict[str, str] = {}
+        for season in show.seasons:
+            season_id = _season_identifier(season)
+            rating_key = _match_season_key(plex_seasons, season)
+            if rating_key:
+                season_rating_cache[season_id] = rating_key
+
+        # Determine which seasons need updating
+        seasons_to_update: Set[str] = set()
+        if self.force or change.invalidate_all or is_first_sync:
+            seasons_to_update = {_season_identifier(s) for s in show.seasons}
+        elif change.changed_seasons:
+            seasons_to_update = set(change.changed_seasons)
+
+        # Sync seasons
+        for season in show.seasons:
+            season_id = _season_identifier(season)
+            rating_key = season_rating_cache.get(season_id)
+
+            if not rating_key:
+                LOGGER.warning("Season not found in Plex: %s / %s", show.title, season.title)
+                stats.seasons_not_found += 1
                 continue
-            mapped_episode = _map_episode_metadata(episode, base_url)
-            _apply_metadata(
-                client,
-                episode_rating,
-                mapped_episode,
-                type_code=METADATA_TYPE["episode"],
-                label=f"episode '{episode.title}'",
-                dry_run=dry_run,
-            )
+
+            if season_id in seasons_to_update:
+                mapped = _map_season_metadata(season, base_url)
+                if _apply_metadata(
+                    self.client,
+                    rating_key,
+                    mapped,
+                    type_code=PLEX_TYPE_SEASON,
+                    label=f"season '{season.title}'",
+                    dry_run=self.dry_run,
+                    stats=stats,
+                ):
+                    stats.seasons_updated += 1
+                else:
+                    stats.seasons_skipped += 1
+            else:
+                stats.seasons_skipped += 1
+
+        # Sync episodes (with caching to avoid N+1)
+        episode_cache: Dict[str, List[Dict[str, Any]]] = {}
+
+        for season in show.seasons:
+            season_id = _season_identifier(season)
+            rating_key = season_rating_cache.get(season_id)
+
+            if not rating_key:
+                continue
+
+            # Fetch and cache episodes for this season
+            if season_id not in episode_cache:
+                episode_cache[season_id] = self.client.list_children(rating_key)
+                stats.api_calls += 1
+
+            plex_episodes = episode_cache[season_id]
+
+            # Get previous episode hashes for change detection
+            previous_episode_hashes: Dict[str, str] = {}
+            if previous_fingerprint:
+                previous_episode_hashes = previous_fingerprint.episode_hashes.get(season_id, {})
+
+            current_episode_hashes = fingerprint.episode_hashes.get(season_id, {})
+
+            for episode in season.episodes:
+                episode_id = _episode_identifier(episode)
+                episode_rating = _match_episode_key(plex_episodes, episode)
+
+                if not episode_rating:
+                    LOGGER.warning(
+                        "Episode not found in Plex: %s / %s / %s",
+                        show.title,
+                        season.title,
+                        episode.title,
+                    )
+                    stats.episodes_not_found += 1
+                    continue
+
+                # Check if episode changed
+                current_hash = current_episode_hashes.get(episode_id)
+                previous_hash = previous_episode_hashes.get(episode_id)
+                episode_changed = (
+                    self.force
+                    or is_first_sync
+                    or change.invalidate_all
+                    or season_id in change.changed_seasons
+                    or episode_id in change.changed_episodes.get(season_id, set())
+                    or current_hash != previous_hash
+                    or previous_hash is None
+                )
+
+                if not episode_changed:
+                    stats.episodes_skipped += 1
+                    continue
+
+                mapped = _map_episode_metadata(episode, base_url)
+                if _apply_metadata(
+                    self.client,
+                    episode_rating,
+                    mapped,
+                    type_code=PLEX_TYPE_EPISODE,
+                    label=f"episode '{episode.title}'",
+                    dry_run=self.dry_run,
+                    stats=stats,
+                ):
+                    stats.episodes_updated += 1
+                else:
+                    stats.episodes_skipped += 1
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
-    args = _parse_args(argv)
-    _configure_logging(args.verbose)
+def create_plex_sync_from_config(config: AppConfig) -> Optional[PlexMetadataSync]:
+    """Create a PlexMetadataSync instance from config with env var overrides.
+
+    Returns None if sync is disabled.
+    """
+    plex_cfg = config.settings.plex_sync
+
+    # Check if enabled
+    env_enabled = env_bool("PLEX_SYNC_ENABLED")
+    enabled = plex_cfg.enabled if env_enabled is None else env_enabled
+    if not enabled:
+        return None
+
+    # Resolve settings
+    env_force = env_bool("PLEX_FORCE")
+    env_dry_run = env_bool("PLEX_SYNC_DRY_RUN")
+    env_sports = env_list("PLEX_SPORTS")
+
+    return PlexMetadataSync(
+        config=config,
+        force=plex_cfg.force if env_force is None else env_force,
+        dry_run=plex_cfg.dry_run if env_dry_run is None else env_dry_run,
+        sports_filter=env_sports if env_sports is not None else (plex_cfg.sports or None),
+    )
+
+
+# Legacy CLI entrypoint (can be removed once integrated into processor)
+def main() -> int:
+    """CLI entrypoint for standalone execution."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Sync Plex metadata from remote YAML.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(os.getenv("CONFIG_PATH", "/config/playbook.yaml")),
+        help="Path to playbook YAML config",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s | %(levelname)-8s | %(name)s\n%(message)s\n",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    from .config import load_config
+
     try:
         config = load_config(args.config)
     except Exception as exc:  # noqa: BLE001
         LOGGER.exception("Failed to load config: %s", exc)
         return 1
 
-    plex_cfg = config.settings.plex_sync
-
-    env_enabled = _env_bool("PLEX_SYNC_ENABLED")
-    enabled = plex_cfg.enabled if env_enabled is None else env_enabled
-    if not enabled:
-        LOGGER.info("Plex metadata sync is disabled; set settings.plex_metadata_sync.enabled or PLEX_SYNC_ENABLED=true")
+    sync = create_plex_sync_from_config(config)
+    if sync is None:
+        LOGGER.info(
+            "Plex metadata sync is disabled; "
+            "set settings.plex_metadata_sync.enabled or PLEX_SYNC_ENABLED=true"
+        )
         return 0
 
-    plex_url = os.getenv("PLEX_URL") or plex_cfg.url
-    plex_token = os.getenv("PLEX_TOKEN") or plex_cfg.token
-    plex_library_id = os.getenv("PLEX_LIBRARY_ID") or plex_cfg.library_id
-    plex_library_name = os.getenv("PLEX_LIBRARY_NAME") or plex_cfg.library_name
-
-    env_timeout = os.getenv("PLEX_TIMEOUT")
     try:
-        timeout = float(env_timeout) if env_timeout is not None else plex_cfg.timeout
-    except ValueError:
-        LOGGER.error("Invalid PLEX_TIMEOUT value; must be numeric")
-        return 1
-
-    env_force = _env_bool("PLEX_FORCE")
-    env_dry_run = _env_bool("PLEX_SYNC_DRY_RUN")
-    force = plex_cfg.force if env_force is None else env_force
-    dry_run = plex_cfg.dry_run if env_dry_run is None else env_dry_run
-
-    env_sports = _env_list("PLEX_SPORTS")
-    sports_filter = env_sports if env_sports is not None else plex_cfg.sports
-
-    if not plex_url or not plex_token:
-        LOGGER.error("Plex URL and token are required (configure settings.plex_metadata_sync or env PLEX_URL/PLEX_TOKEN)")
-        return 1
-
-    if not plex_library_id and not plex_library_name:
-        LOGGER.error("Provide a Plex library id or name (settings.plex_metadata_sync.library_id / library_name or env PLEX_LIBRARY_ID / PLEX_LIBRARY_NAME)")
-        return 1
-
-    client = PlexClient(plex_url, plex_token, timeout=timeout)
-    try:
-        library_id = client.find_library(library_id=plex_library_id, library_name=plex_library_name)
+        stats = sync.sync_all()
     except PlexApiError as exc:
-        LOGGER.error("%s", exc)
+        LOGGER.error("Plex sync failed: %s", exc)
         return 2
 
-    fingerprint_store = MetadataFingerprintStore(config.settings.cache_dir, filename="plex-metadata-hashes.json")
-    sports = (
-        [sport for sport in config.sports if sport.id in set(sports_filter)]
-        if sports_filter
-        else list(config.sports)
-    )
-    if not sports:
-        LOGGER.info("No sports selected; exiting")
-        return 0
-
-    for sport in sports:
-        try:
-            _sync_single_sport(
-                client=client,
-                library_id=library_id,
-                config=config,
-                sport=sport,
-                fingerprint_store=fingerprint_store,
-                force=force,
-                dry_run=dry_run,
-            )
-        except PlexApiError as exc:
-            LOGGER.error("Plex API error for sport %s: %s", sport.id, exc)
-        except Exception as exc:  # noqa: BLE001
-            LOGGER.exception("Unexpected error while syncing %s: %s", sport.id, exc)
-
-    fingerprint_store.save()
-    LOGGER.info("Completed Plex metadata sync")
-    return 0
+    return 1 if stats.errors else 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    import sys
 
+    sys.exit(main())

--- a/tests/test_plex_client.py
+++ b/tests/test_plex_client.py
@@ -1,0 +1,169 @@
+"""Tests for Plex client and metadata sync."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from playbook.plex_client import (
+    PLEX_TYPE_EPISODE,
+    PLEX_TYPE_SEASON,
+    PLEX_TYPE_SHOW,
+    PlexApiError,
+    PlexClient,
+    PlexSyncStats,
+    validate_plex_url,
+)
+
+
+class TestValidatePlexUrl:
+    def test_valid_http_url(self) -> None:
+        assert validate_plex_url("http://localhost:32400") is True
+
+    def test_valid_https_url(self) -> None:
+        assert validate_plex_url("https://plex.example.com") is True
+
+    def test_valid_url_with_path(self) -> None:
+        assert validate_plex_url("http://plex:32400/api") is True
+
+    def test_invalid_no_scheme(self) -> None:
+        assert validate_plex_url("localhost:32400") is False
+
+    def test_invalid_file_scheme(self) -> None:
+        assert validate_plex_url("file:///etc/passwd") is False
+
+    def test_invalid_empty(self) -> None:
+        assert validate_plex_url("") is False
+
+    def test_invalid_none(self) -> None:
+        assert validate_plex_url(None) is False
+
+    def test_invalid_just_scheme(self) -> None:
+        assert validate_plex_url("http://") is False
+
+
+class TestPlexClient:
+    def test_init_validates_url(self) -> None:
+        with pytest.raises(PlexApiError, match="Invalid Plex URL"):
+            PlexClient("not-a-url", "token")
+
+    def test_init_accepts_valid_url(self) -> None:
+        client = PlexClient("http://localhost:32400", "token123")
+        assert client.base_url == "http://localhost:32400"
+        assert client.token == "token123"
+
+    def test_token_passed_in_header_not_params(self) -> None:
+        """Verify token is sent via header for security."""
+        client = PlexClient("http://localhost:32400", "secret-token")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"MediaContainer": {}}
+
+        with patch.object(client.session, "request", return_value=mock_response) as mock_req:
+            client._request("GET", "/test")
+
+            call_kwargs = mock_req.call_args[1]
+            headers = call_kwargs.get("headers", {})
+            params = call_kwargs.get("params", {})
+
+            # Token should be in headers
+            assert headers.get("X-Plex-Token") == "secret-token"
+            # Token should NOT be in params
+            assert "X-Plex-Token" not in params
+
+    def test_update_metadata_with_field_locking(self) -> None:
+        """Verify field locking is applied."""
+        client = PlexClient("http://localhost:32400", "token")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(client.session, "request", return_value=mock_response) as mock_req:
+            client.update_metadata("12345", {"title": "Test", "summary": "A summary"})
+
+            call_kwargs = mock_req.call_args[1]
+            params = call_kwargs.get("params", {})
+
+            # Should have .value and .locked for each field
+            assert params.get("title.value") == "Test"
+            assert params.get("title.locked") == 1
+            assert params.get("summary.value") == "A summary"
+            assert params.get("summary.locked") == 1
+
+    def test_update_metadata_without_locking(self) -> None:
+        """Verify field locking can be disabled."""
+        client = PlexClient("http://localhost:32400", "token")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(client.session, "request", return_value=mock_response) as mock_req:
+            client.update_metadata("12345", {"title": "Test"}, lock_fields=False)
+
+            call_kwargs = mock_req.call_args[1]
+            params = call_kwargs.get("params", {})
+
+            assert params.get("title.value") == "Test"
+            assert "title.locked" not in params
+
+    def test_set_asset_validates_element(self) -> None:
+        """Verify invalid asset element names are rejected."""
+        client = PlexClient("http://localhost:32400", "token")
+        with pytest.raises(PlexApiError, match="Invalid asset element"):
+            client.set_asset("12345", "poster", "http://example.com/img.jpg")
+
+    def test_set_asset_accepts_valid_elements(self) -> None:
+        """Verify valid asset element names work."""
+        client = PlexClient("http://localhost:32400", "token")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(client.session, "request", return_value=mock_response):
+            # thumb is the correct name for poster
+            client.set_asset("12345", "thumb", "http://example.com/poster.jpg")
+            # art is the correct name for background
+            client.set_asset("12345", "art", "http://example.com/bg.jpg")
+
+
+class TestPlexSyncStats:
+    def test_empty_stats_no_activity(self) -> None:
+        stats = PlexSyncStats()
+        assert stats.has_activity() is False
+
+    def test_stats_with_updates_has_activity(self) -> None:
+        stats = PlexSyncStats()
+        stats.shows_updated = 1
+        assert stats.has_activity() is True
+
+    def test_stats_with_errors_has_activity(self) -> None:
+        stats = PlexSyncStats()
+        stats.errors.append("Something failed")
+        assert stats.has_activity() is True
+
+    def test_summary_returns_dict(self) -> None:
+        stats = PlexSyncStats()
+        stats.shows_updated = 2
+        stats.seasons_updated = 5
+        stats.episodes_updated = 20
+        stats.api_calls = 50
+
+        summary = stats.summary()
+        assert summary["shows"]["updated"] == 2
+        assert summary["seasons"]["updated"] == 5
+        assert summary["episodes"]["updated"] == 20
+        assert summary["api_calls"] == 50
+
+
+class TestPlexTypeConstants:
+    """Verify Plex type constants match openapi.json spec."""
+
+    def test_show_type(self) -> None:
+        assert PLEX_TYPE_SHOW == 2
+
+    def test_season_type(self) -> None:
+        assert PLEX_TYPE_SEASON == 3
+
+    def test_episode_type(self) -> None:
+        assert PLEX_TYPE_EPISODE == 4
+

--- a/tests/test_plex_metadata_sync.py
+++ b/tests/test_plex_metadata_sync.py
@@ -1,0 +1,312 @@
+"""Tests for Plex metadata sync functionality."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from playbook.models import Episode, Season, Show
+from playbook.plex_metadata_sync import (
+    MappedMetadata,
+    _as_int,
+    _episode_identifier,
+    _first,
+    _map_episode_metadata,
+    _map_season_metadata,
+    _map_show_metadata,
+    _match_episode_key,
+    _match_season_key,
+    _parse_date,
+    _resolve_asset_url,
+    _season_identifier,
+)
+
+
+def _make_episode(
+    index: int = 1,
+    title: str = "Test",
+    *,
+    summary: Optional[str] = None,
+    originally_available: Optional[dt.date] = None,
+    display_number: Optional[int] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Episode:
+    """Helper to create Episode with defaults."""
+    ep = Episode(
+        title=title,
+        summary=summary,
+        originally_available=originally_available,
+        index=index,
+        display_number=display_number,
+    )
+    if metadata:
+        ep.metadata = metadata
+    return ep
+
+
+def _make_season(
+    index: int = 1,
+    key: str = "season-1",
+    title: str = "Season 1",
+    *,
+    summary: Optional[str] = None,
+    display_number: Optional[int] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    episodes: Optional[list] = None,
+) -> Season:
+    """Helper to create Season with defaults."""
+    season = Season(
+        key=key,
+        title=title,
+        summary=summary,
+        index=index,
+        episodes=episodes or [],
+        display_number=display_number,
+    )
+    if metadata:
+        season.metadata = metadata
+    return season
+
+
+def _make_show(
+    key: str = "show-1",
+    title: str = "Test Show",
+    *,
+    summary: Optional[str] = None,
+    seasons: Optional[list] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Show:
+    """Helper to create Show with defaults."""
+    show = Show(
+        key=key,
+        title=title,
+        summary=summary,
+        seasons=seasons or [],
+    )
+    if metadata:
+        show.metadata = metadata
+    return show
+
+
+class TestParseDate:
+    def test_parses_date_object(self) -> None:
+        result = _parse_date(dt.date(2024, 1, 15))
+        assert result == "2024-01-15"
+
+    def test_parses_datetime_object(self) -> None:
+        result = _parse_date(dt.datetime(2024, 1, 15, 10, 30))
+        assert result == "2024-01-15"
+
+    def test_parses_iso_string(self) -> None:
+        result = _parse_date("2024-01-15")
+        assert result == "2024-01-15"
+
+    def test_parses_datetime_string(self) -> None:
+        result = _parse_date("2024-01-15 10:30:00")
+        assert result == "2024-01-15"
+
+    def test_returns_none_for_invalid(self) -> None:
+        assert _parse_date("not-a-date") is None
+
+    def test_returns_none_for_none(self) -> None:
+        assert _parse_date(None) is None
+
+
+class TestResolveAssetUrl:
+    def test_returns_none_for_empty(self) -> None:
+        assert _resolve_asset_url("http://base", "") is None
+        assert _resolve_asset_url("http://base", None) is None
+
+    def test_returns_absolute_url_unchanged(self) -> None:
+        url = "https://example.com/image.jpg"
+        assert _resolve_asset_url("http://base", url) == url
+
+    def test_resolves_relative_path(self) -> None:
+        result = _resolve_asset_url("http://base.com/api/", "assets/poster.jpg")
+        assert result == "http://base.com/api/assets/poster.jpg"
+
+    def test_handles_leading_slash(self) -> None:
+        result = _resolve_asset_url("http://base.com", "/assets/poster.jpg")
+        assert result == "http://base.com/assets/poster.jpg"
+
+
+class TestFirst:
+    def test_returns_first_found(self) -> None:
+        meta = {"title": "", "name": "Show Name", "label": "Label"}
+        result = _first(meta, ("title", "name", "label"))
+        assert result == "Show Name"
+
+    def test_returns_none_if_all_empty(self) -> None:
+        meta = {"title": "", "name": None}
+        result = _first(meta, ("title", "name"))
+        assert result is None
+
+    def test_skips_missing_keys(self) -> None:
+        meta = {"name": "Found"}
+        result = _first(meta, ("missing", "name"))
+        assert result == "Found"
+
+
+class TestAsInt:
+    def test_converts_int(self) -> None:
+        assert _as_int(42) == 42
+
+    def test_converts_string(self) -> None:
+        assert _as_int("42") == 42
+
+    def test_returns_none_for_invalid(self) -> None:
+        assert _as_int("not-a-number") is None
+
+    def test_returns_none_for_none(self) -> None:
+        assert _as_int(None) is None
+
+
+class TestSeasonIdentifier:
+    def test_uses_key_if_present(self) -> None:
+        season = _make_season(index=1, key="season-key-123", title="Season 1")
+        assert _season_identifier(season) == "season-key-123"
+
+    def test_uses_display_number(self) -> None:
+        season = _make_season(index=1, key="", title="Season 1", display_number=2)
+        # When key is empty but display_number is set, should use display_number
+        result = _season_identifier(season)
+        # Empty key should fall through to display_number
+        assert "display:2" in result or result == ""
+
+    def test_falls_back_to_index(self) -> None:
+        season = _make_season(index=3, key="", title="Season 3")
+        result = _season_identifier(season)
+        # Empty key, no display_number, should use index
+        assert "index:3" in result or result == ""
+
+
+class TestEpisodeIdentifier:
+    def test_uses_metadata_id(self) -> None:
+        episode = _make_episode(index=1, title="Race", metadata={"id": "ep-123"})
+        assert _episode_identifier(episode) == "id:ep-123"
+
+    def test_uses_display_number(self) -> None:
+        episode = _make_episode(index=1, title="Race", display_number=5)
+        assert _episode_identifier(episode) == "display:5"
+
+    def test_uses_title(self) -> None:
+        episode = _make_episode(index=1, title="Grand Prix")
+        assert _episode_identifier(episode) == "title:Grand Prix"
+
+    def test_falls_back_to_index(self) -> None:
+        episode = _make_episode(index=7, title="")
+        assert _episode_identifier(episode) == "index:7"
+
+
+class TestMatchSeasonKey:
+    def test_matches_by_index(self) -> None:
+        plex_seasons = [
+            {"ratingKey": "100", "index": 1, "title": "Season 1"},
+            {"ratingKey": "200", "index": 2, "title": "Season 2"},
+        ]
+        season = _make_season(index=2, title="Season 2")
+        assert _match_season_key(plex_seasons, season) == "200"
+
+    def test_matches_by_display_number(self) -> None:
+        plex_seasons = [
+            {"ratingKey": "100", "seasonNumber": 2024, "title": "2024"},
+        ]
+        season = _make_season(index=1, title="2024", display_number=2024)
+        assert _match_season_key(plex_seasons, season) == "100"
+
+    def test_matches_by_title(self) -> None:
+        plex_seasons = [
+            {"ratingKey": "100", "index": 0, "title": "Specials"},
+        ]
+        season = _make_season(index=99, title="Specials")
+        assert _match_season_key(plex_seasons, season) == "100"
+
+    def test_returns_none_if_not_found(self) -> None:
+        plex_seasons = [
+            {"ratingKey": "100", "index": 1, "title": "Season 1"},
+        ]
+        season = _make_season(index=5, title="Season 5")
+        assert _match_season_key(plex_seasons, season) is None
+
+
+class TestMatchEpisodeKey:
+    def test_matches_by_index(self) -> None:
+        plex_episodes = [
+            {"ratingKey": "500", "index": 1, "title": "Qualifying"},
+            {"ratingKey": "501", "index": 2, "title": "Race"},
+        ]
+        episode = _make_episode(index=2, title="Race")
+        assert _match_episode_key(plex_episodes, episode) == "501"
+
+    def test_matches_by_display_number(self) -> None:
+        plex_episodes = [
+            {"ratingKey": "500", "index": 3, "title": "Event"},
+        ]
+        episode = _make_episode(index=1, title="Event", display_number=3)
+        assert _match_episode_key(plex_episodes, episode) == "500"
+
+    def test_matches_by_title(self) -> None:
+        plex_episodes = [
+            {"ratingKey": "500", "index": 1, "title": "Monaco Grand Prix"},
+        ]
+        episode = _make_episode(index=99, title="Monaco Grand Prix")
+        assert _match_episode_key(plex_episodes, episode) == "500"
+
+
+class TestMapShowMetadata:
+    def test_extracts_basic_fields(self) -> None:
+        show = _make_show(
+            title="F1 2024",
+            summary="Formula 1 Season",
+            metadata={
+                "sort_title": "Formula 1 2024",
+                "original_title": "Formula One",
+                "originally_available": "2024-03-01",
+                "poster": "posters/f1.jpg",
+                "background": "backgrounds/f1.jpg",
+            },
+        )
+        result = _map_show_metadata(show, "http://cdn.example.com")
+
+        assert result.title == "F1 2024"
+        assert result.summary == "Formula 1 Season"
+        assert result.sort_title == "Formula 1 2024"
+        assert result.original_title == "Formula One"
+        assert result.originally_available_at == "2024-03-01"
+        assert result.poster_url == "http://cdn.example.com/posters/f1.jpg"
+        assert result.background_url == "http://cdn.example.com/backgrounds/f1.jpg"
+
+
+class TestMapSeasonMetadata:
+    def test_extracts_basic_fields(self) -> None:
+        season = _make_season(
+            index=1,
+            title="2024 Season",
+            summary="The 2024 racing season",
+            metadata={"poster": "http://absolute.com/poster.jpg"},
+        )
+        result = _map_season_metadata(season, "http://cdn.example.com")
+
+        assert result.title == "2024 Season"
+        assert result.summary == "The 2024 racing season"
+        assert result.poster_url == "http://absolute.com/poster.jpg"
+
+
+class TestMapEpisodeMetadata:
+    def test_extracts_basic_fields(self) -> None:
+        episode = _make_episode(
+            index=1,
+            title="Monaco Grand Prix",
+            summary="The crown jewel of F1",
+            originally_available=dt.date(2024, 5, 26),
+            metadata={"poster": "episodes/monaco.jpg"},
+        )
+        result = _map_episode_metadata(episode, "http://cdn.example.com")
+
+        assert result.title == "Monaco Grand Prix"
+        assert result.summary == "The crown jewel of F1"
+        assert result.originally_available_at == "2024-05-26"
+        assert result.poster_url == "http://cdn.example.com/episodes/monaco.jpg"

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -246,14 +246,14 @@ def test_run_recap_lists_destinations(tmp_path, caplog) -> None:
     stats = ProcessingStats()
     stats.register_processed()
     processor._touched_destinations = {"Demo/Season 01/Race.mkv"}
-    processor._kometa_trigger_fired = True
 
     with caplog.at_level(logging.INFO, logger="playbook.processor"):
         processor._log_run_recap(stats, duration=1.25)
 
     text = caplog.text
     assert "Run Recap" in text
-    assert "Kometa Triggered" in text and "yes" in text
+    # Plex sync status is always shown (disabled when not configured)
+    assert "Plex Sync" in text
     assert "Demo/Season 01/Race.mkv" in text
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import os
+
+import pytest
+
 from playbook.utils import (
+    env_bool,
+    env_list,
     link_file,
     normalize_token,
+    parse_env_bool,
     sanitize_component,
     slugify,
+    validate_url,
 )
 
 
@@ -41,4 +49,82 @@ def test_link_file_creates_destination_and_detects_existing(tmp_path) -> None:
     second = link_file(source, destination)
     assert second.created is False
     assert second.reason == "destination-exists"
+
+
+class TestParseEnvBool:
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "YES", "on", "ON"])
+    def test_parses_truthy_values(self, value: str) -> None:
+        assert parse_env_bool(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "0", "no", "NO", "off", "OFF"])
+    def test_parses_falsy_values(self, value: str) -> None:
+        assert parse_env_bool(value) is False
+
+    def test_returns_none_for_none(self) -> None:
+        assert parse_env_bool(None) is None
+
+    def test_returns_none_for_unrecognized(self) -> None:
+        assert parse_env_bool("maybe") is None
+        assert parse_env_bool("") is None
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_env_bool("  true  ") is True
+
+
+class TestEnvBool:
+    def test_reads_from_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEST_BOOL", "true")
+        assert env_bool("TEST_BOOL") is True
+
+        monkeypatch.setenv("TEST_BOOL", "false")
+        assert env_bool("TEST_BOOL") is False
+
+    def test_returns_none_when_not_set(self, monkeypatch) -> None:
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+        assert env_bool("NONEXISTENT_VAR") is None
+
+
+class TestEnvList:
+    def test_parses_comma_separated(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEST_LIST", "a,b,c")
+        assert env_list("TEST_LIST") == ["a", "b", "c"]
+
+    def test_strips_whitespace(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEST_LIST", "  a , b , c  ")
+        assert env_list("TEST_LIST") == ["a", "b", "c"]
+
+    def test_filters_empty_parts(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEST_LIST", "a,,b,  ,c")
+        assert env_list("TEST_LIST") == ["a", "b", "c"]
+
+    def test_returns_empty_list_for_empty_value(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEST_LIST", "")
+        assert env_list("TEST_LIST") == []
+
+    def test_returns_none_when_not_set(self, monkeypatch) -> None:
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+        assert env_list("NONEXISTENT_VAR") is None
+
+
+class TestValidateUrl:
+    def test_accepts_http(self) -> None:
+        assert validate_url("http://localhost:32400") is True
+
+    def test_accepts_https(self) -> None:
+        assert validate_url("https://plex.example.com") is True
+
+    def test_rejects_missing_scheme(self) -> None:
+        assert validate_url("localhost:32400") is False
+
+    def test_rejects_file_scheme(self) -> None:
+        assert validate_url("file:///etc/passwd") is False
+
+    def test_rejects_empty(self) -> None:
+        assert validate_url("") is False
+
+    def test_rejects_none(self) -> None:
+        assert validate_url(None) is False
+
+    def test_rejects_invalid_url(self) -> None:
+        assert validate_url("http://") is False
 


### PR DESCRIPTION
- Improved `plex_metadata_sync` settings in `playbook.sample.yaml` for better configuration options, including clearer descriptions for parameters like `library_id` and `timeout`.
- Added URL validation in `config.py` to ensure proper format for Plex server URLs.
- Updated documentation in `operations.md` to provide detailed guidance on the new Plex sync features and their configuration.
- Enhanced the Plex client with automatic retries and rate limiting for more resilient API interactions.
- Introduced new metadata sync statistics tracking to provide insights into the sync process.
- Refactored metadata handling to streamline updates for shows, seasons, and episodes, ensuring efficient synchronization with Plex.