### PR TITLE
feat: add library scan functionality and fuzzy search improvements

### DIFF
--- a/config/playbook.sample.yaml
+++ b/config/playbook.sample.yaml
@@ -125,8 +125,9 @@ settings:
     force: ${PLEX_FORCE:-false}      # Force all updates even if unchanged
     dry_run: ${PLEX_SYNC_DRY_RUN:-false} # Log only, no Plex writes
     sports: []                       # Limit to specific sport ids; env PLEX_SPORTS=foo,bar
-    # Features: automatic retry with backoff, rate limiting, field locking,
-    # fingerprint-based change detection for shows/seasons/episodes
+    scan_wait: 5                     # Seconds to wait after triggering library scan (0 to skip)
+    # Features: automatic library scan trigger, retry with backoff, rate limiting,
+    # field locking, fingerprint-based change detection for shows/seasons/episodes
 
   ####################################################################
   # DEFAULT DESTINATION TEMPLATES

--- a/src/playbook/config.py
+++ b/src/playbook/config.py
@@ -41,6 +41,7 @@ class PlexSyncSettings:
     force: bool = False
     dry_run: bool = False
     sports: List[str] = field(default_factory=list)
+    scan_wait: float = 5.0  # Seconds to wait after triggering library scan
 
 
 @dataclass(slots=True)
@@ -428,6 +429,12 @@ def _build_plex_sync_settings(data: Dict[str, Any]) -> PlexSyncSettings:
             f"'plex_metadata_sync.url' must be a valid http/https URL, got: {url}"
         )
 
+    scan_wait_raw = data.get("scan_wait", 5.0)
+    try:
+        scan_wait = float(scan_wait_raw)
+    except (TypeError, ValueError):
+        scan_wait = 5.0
+
     return PlexSyncSettings(
         enabled=enabled,
         url=url,
@@ -438,6 +445,7 @@ def _build_plex_sync_settings(data: Dict[str, Any]) -> PlexSyncSettings:
         force=bool(data.get("force", False)),
         dry_run=bool(data.get("dry_run", False)),
         sports=sports,
+        scan_wait=scan_wait,
     )
 
 


### PR DESCRIPTION
- Introduced `scan_wait` parameter in `playbook.sample.yaml` and `PlexSyncSettings` to control the wait time after triggering a library scan.
- Enhanced `search_show` method in `PlexClient` to support fuzzy matching for show titles, improving search accuracy.
- Updated `PlexMetadataSync` to trigger a library scan before syncing, ensuring new files are recognized by Plex.
- Added tests for fuzzy title matching to validate the new search functionality.