### PR TITLE
feat: enhance Plex metadata sync functionality and documentation

### DIFF
--- a/config/playbook.sample.yaml
+++ b/config/playbook.sample.yaml
@@ -109,12 +109,20 @@ settings:
       #   - On macOS, also mount com.docker.cli (command -v com.docker.cli)
 
   ####################################################################
-  # PLEX METADATA PRE-SYNC (OPTIONAL)
+  # PLEX METADATA SYNC (OPTIONAL)
   ####################################################################
   # Push show/season/episode metadata (titles, sort titles, summaries, dates,
-  # posters, backgrounds) to Plex before Kometa runs. Uses remote metadata YAML
-  # as the source of truth. Episodes are always updated; shows/seasons update on
-  # first run or when the metadata fingerprint changes (or when force is true).
+  # posters, backgrounds) to Plex. Uses remote metadata YAML as the source of truth.
+  #
+  # SYNC TRIGGERS:
+  #   - New files processed (automatically syncs the affected sports)
+  #   - Metadata changed in remote YAML (fingerprint-based detection)
+  #   - First-time sync (sports that have never been synced will auto-sync)
+  #   - Force mode (force: true syncs all sports regardless of state)
+  #
+  # This "first-time sync" feature ensures that existing content in Plex gets
+  # proper metadata even if you enable sync after already having files in place.
+  # Once a sport is synced, it only re-syncs when metadata changes or force=true.
   plex_metadata_sync:
     enabled: false                   # Set true to enable; or PLEX_SYNC_ENABLED=true
     url: ${PLEX_URL:-http://plex:32400}
@@ -127,7 +135,7 @@ settings:
     sports: []                       # Limit to specific sport ids; env PLEX_SPORTS=foo,bar
     scan_wait: 5                     # Seconds to wait after triggering library scan (0 to skip)
     # Features: automatic library scan trigger, retry with backoff, rate limiting,
-    # field locking, fingerprint-based change detection for shows/seasons/episodes
+    # field locking, fingerprint-based change detection, first-time sync detection
 
   ####################################################################
   # DEFAULT DESTINATION TEMPLATES

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -82,11 +82,17 @@ Playbook can push show/season/episode metadata (titles, sort titles, summaries, 
 
 **How it works:**
 
-1. **Automatic**: When enabled, Plex sync runs automatically after file processing if any files were processed or metadata changed.
-2. **Change detection**: Uses fingerprint-based detection—shows/seasons only update when metadata changes; episodes update when their content changes.
-3. **Field locking**: Sets `{field}.locked=1` to prevent Plex agents from overwriting your custom metadata.
-4. **Rate limiting**: Built-in rate limiting and retry logic for resilient API calls.
-5. **Security**: Token passed via header (not URL query params); URLs sanitized in logs.
+1. **Automatic**: When enabled, Plex sync runs automatically after file processing.
+2. **Smart sync decision**: Sync runs when:
+   - New files were processed
+   - Metadata changed in remote YAML
+   - Sports have never been synced to Plex (first-time sync)
+   - Force mode is enabled
+3. **Change detection**: Uses fingerprint-based detection—shows/seasons only update when metadata changes; episodes update when their content changes.
+4. **First-time sync**: If a sport has never been synced to Plex, it will sync automatically even if no new files were processed. This ensures existing content gets proper metadata.
+5. **Field locking**: Sets `{field}.locked=1` to prevent Plex agents from overwriting your custom metadata.
+6. **Rate limiting**: Built-in rate limiting and retry logic for resilient API calls.
+7. **Security**: Token passed via header (not URL query params); URLs sanitized in logs.
 
 **Manual execution:**
 
@@ -94,7 +100,9 @@ Playbook can push show/season/episode metadata (titles, sort titles, summaries, 
 python -m playbook.plex_metadata_sync --config /config/playbook.yaml --verbose
 ```
 
-**Fingerprint cache**: Stored in `cache_dir/state/plex-metadata-hashes.json`.
+**State files** (stored in `cache_dir/state/`):
+- `plex-metadata-hashes.json`: Fingerprint cache for change detection
+- `plex-sync-state.json`: Tracks which sports have been synced to Plex
 
 ## Logging & Observability
 

--- a/src/playbook/plex_sync_state.py
+++ b/src/playbook/plex_sync_state.py
@@ -1,0 +1,186 @@
+"""Track Plex sync state to detect first-run and changes."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional, Set
+
+from .utils import ensure_directory
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SportSyncState:
+    """State of a single sport's Plex sync."""
+
+    fingerprint: str  # Metadata fingerprint at time of last successful sync
+    synced_at: str  # ISO timestamp of last successful sync
+    shows_synced: int = 0
+    seasons_synced: int = 0
+    episodes_synced: int = 0
+
+
+@dataclass(slots=True)
+class PlexSyncState:
+    """Tracks what has been successfully synced to Plex.
+
+    This allows us to:
+    1. Detect first-time sync (sport not in state)
+    2. Detect metadata changes since last sync
+    3. Skip sync only when already synced AND unchanged
+    """
+
+    sports: Dict[str, SportSyncState] = field(default_factory=dict)
+    _dirty: bool = field(default=False, repr=False)
+
+    def needs_sync(self, sport_id: str, current_fingerprint: str) -> bool:
+        """Check if a sport needs to be synced.
+
+        Returns True if:
+        - Sport has never been synced (first run)
+        - Sport's metadata has changed since last sync
+        """
+        state = self.sports.get(sport_id)
+        if state is None:
+            LOGGER.debug("Sport '%s' needs sync: never synced before", sport_id)
+            return True
+        if state.fingerprint != current_fingerprint:
+            LOGGER.debug(
+                "Sport '%s' needs sync: fingerprint changed (%s -> %s)",
+                sport_id,
+                state.fingerprint[:8],
+                current_fingerprint[:8],
+            )
+            return True
+        return False
+
+    def mark_synced(
+        self,
+        sport_id: str,
+        fingerprint: str,
+        *,
+        shows: int = 0,
+        seasons: int = 0,
+        episodes: int = 0,
+    ) -> None:
+        """Mark a sport as successfully synced."""
+        import datetime as dt
+
+        self.sports[sport_id] = SportSyncState(
+            fingerprint=fingerprint,
+            synced_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+            shows_synced=shows,
+            seasons_synced=seasons,
+            episodes_synced=episodes,
+        )
+        self._dirty = True
+
+    def get_unsynced_sports(self, sport_ids: Set[str], fingerprints: Dict[str, str]) -> Set[str]:
+        """Get sports that need syncing (never synced or changed)."""
+        needs_sync = set()
+        for sport_id in sport_ids:
+            fingerprint = fingerprints.get(sport_id, "")
+            if self.needs_sync(sport_id, fingerprint):
+                needs_sync.add(sport_id)
+        return needs_sync
+
+    @property
+    def is_dirty(self) -> bool:
+        return self._dirty
+
+
+class PlexSyncStateStore:
+    """Persistent storage for Plex sync state."""
+
+    def __init__(self, cache_dir: Path, filename: str = "plex-sync-state.json") -> None:
+        self.cache_dir = cache_dir
+        self.state_file = cache_dir / "state" / filename
+        self._state: Optional[PlexSyncState] = None
+
+    @property
+    def state(self) -> PlexSyncState:
+        if self._state is None:
+            self._state = self._load()
+        return self._state
+
+    def _load(self) -> PlexSyncState:
+        if not self.state_file.exists():
+            LOGGER.debug("Plex sync state file not found, starting fresh")
+            return PlexSyncState()
+
+        try:
+            with self.state_file.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            LOGGER.warning("Failed to load Plex sync state: %s", exc)
+            return PlexSyncState()
+
+        sports: Dict[str, SportSyncState] = {}
+        for sport_id, sport_data in data.get("sports", {}).items():
+            try:
+                sports[sport_id] = SportSyncState(
+                    fingerprint=sport_data.get("fingerprint", ""),
+                    synced_at=sport_data.get("synced_at", ""),
+                    shows_synced=sport_data.get("shows_synced", 0),
+                    seasons_synced=sport_data.get("seasons_synced", 0),
+                    episodes_synced=sport_data.get("episodes_synced", 0),
+                )
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Failed to parse sync state for %s: %s", sport_id, exc)
+
+        return PlexSyncState(sports=sports)
+
+    def save(self) -> None:
+        if self._state is None or not self._state.is_dirty:
+            return
+
+        ensure_directory(self.state_file.parent)
+
+        data: Dict[str, Any] = {"sports": {}}
+        for sport_id, state in self._state.sports.items():
+            data["sports"][sport_id] = {
+                "fingerprint": state.fingerprint,
+                "synced_at": state.synced_at,
+                "shows_synced": state.shows_synced,
+                "seasons_synced": state.seasons_synced,
+                "episodes_synced": state.episodes_synced,
+            }
+
+        try:
+            with self.state_file.open("w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            self._state._dirty = False
+            LOGGER.debug("Saved Plex sync state to %s", self.state_file)
+        except OSError as exc:
+            LOGGER.warning("Failed to save Plex sync state: %s", exc)
+
+    def needs_sync(self, sport_id: str, current_fingerprint: str) -> bool:
+        """Check if a sport needs to be synced."""
+        return self.state.needs_sync(sport_id, current_fingerprint)
+
+    def mark_synced(
+        self,
+        sport_id: str,
+        fingerprint: str,
+        *,
+        shows: int = 0,
+        seasons: int = 0,
+        episodes: int = 0,
+    ) -> None:
+        """Mark a sport as successfully synced."""
+        self.state.mark_synced(
+            sport_id,
+            fingerprint,
+            shows=shows,
+            seasons=seasons,
+            episodes=episodes,
+        )
+
+    def get_unsynced_sports(self, sport_ids: Set[str], fingerprints: Dict[str, str]) -> Set[str]:
+        """Get sports that need syncing."""
+        return self.state.get_unsynced_sports(sport_ids, fingerprints)
+

--- a/tests/test_plex_sync_state.py
+++ b/tests/test_plex_sync_state.py
@@ -1,0 +1,152 @@
+"""Tests for Plex sync state tracking."""
+
+from __future__ import annotations
+
+import json
+import pytest
+from pathlib import Path
+
+from src.playbook.plex_sync_state import (
+    PlexSyncState,
+    PlexSyncStateStore,
+    SportSyncState,
+)
+
+
+class TestSportSyncState:
+    """Tests for SportSyncState dataclass."""
+
+    def test_basic_creation(self) -> None:
+        state = SportSyncState(
+            fingerprint="abc123",
+            synced_at="2024-01-01T00:00:00Z",
+            shows_synced=1,
+            seasons_synced=2,
+            episodes_synced=10,
+        )
+        assert state.fingerprint == "abc123"
+        assert state.synced_at == "2024-01-01T00:00:00Z"
+        assert state.shows_synced == 1
+        assert state.seasons_synced == 2
+        assert state.episodes_synced == 10
+
+
+class TestPlexSyncState:
+    """Tests for PlexSyncState."""
+
+    def test_needs_sync_never_synced(self) -> None:
+        """Sport needs sync if never synced before."""
+        state = PlexSyncState()
+        assert state.needs_sync("nhl", "fp123") is True
+
+    def test_needs_sync_fingerprint_changed(self) -> None:
+        """Sport needs sync if fingerprint changed."""
+        state = PlexSyncState()
+        state.mark_synced("nhl", "old_fp")
+        assert state.needs_sync("nhl", "new_fp") is True
+
+    def test_needs_sync_unchanged(self) -> None:
+        """Sport doesn't need sync if fingerprint unchanged."""
+        state = PlexSyncState()
+        state.mark_synced("nhl", "fp123")
+        assert state.needs_sync("nhl", "fp123") is False
+
+    def test_mark_synced_sets_state(self) -> None:
+        """mark_synced creates proper state entry."""
+        state = PlexSyncState()
+        state.mark_synced("nhl", "fp123", shows=1, seasons=2, episodes=10)
+
+        assert "nhl" in state.sports
+        sport_state = state.sports["nhl"]
+        assert sport_state.fingerprint == "fp123"
+        assert sport_state.shows_synced == 1
+        assert sport_state.seasons_synced == 2
+        assert sport_state.episodes_synced == 10
+        assert sport_state.synced_at  # Should have timestamp
+
+    def test_mark_synced_marks_dirty(self) -> None:
+        """mark_synced sets dirty flag."""
+        state = PlexSyncState()
+        assert state.is_dirty is False
+        state.mark_synced("nhl", "fp123")
+        assert state.is_dirty is True
+
+    def test_get_unsynced_sports(self) -> None:
+        """get_unsynced_sports returns sports needing sync."""
+        state = PlexSyncState()
+        state.mark_synced("nhl", "fp_nhl")
+        state.mark_synced("nfl", "fp_nfl_old")
+
+        # nhl unchanged, nfl changed, mlb never synced
+        fingerprints = {
+            "nhl": "fp_nhl",  # unchanged
+            "nfl": "fp_nfl_new",  # changed
+            "mlb": "fp_mlb",  # new
+        }
+        sport_ids = {"nhl", "nfl", "mlb"}
+
+        unsynced = state.get_unsynced_sports(sport_ids, fingerprints)
+        assert unsynced == {"nfl", "mlb"}
+
+
+class TestPlexSyncStateStore:
+    """Tests for PlexSyncStateStore persistence."""
+
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        """State can be saved and loaded."""
+        store = PlexSyncStateStore(tmp_path)
+        store.mark_synced("nhl", "fp123", shows=1, seasons=2, episodes=10)
+        store.save()
+
+        # Create new store and load
+        store2 = PlexSyncStateStore(tmp_path)
+        assert store2.needs_sync("nhl", "fp123") is False
+        assert store2.needs_sync("nhl", "fp_different") is True
+        assert store2.needs_sync("nfl", "anything") is True
+
+    def test_load_empty_creates_fresh(self, tmp_path: Path) -> None:
+        """Loading without file creates fresh state."""
+        store = PlexSyncStateStore(tmp_path)
+        assert store.needs_sync("nhl", "fp123") is True  # Never synced
+
+    def test_load_corrupt_file_creates_fresh(self, tmp_path: Path) -> None:
+        """Corrupt file creates fresh state."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "plex-sync-state.json").write_text("not valid json {{{")
+
+        store = PlexSyncStateStore(tmp_path)
+        assert store.needs_sync("nhl", "fp123") is True  # Treated as never synced
+
+    def test_save_creates_directory(self, tmp_path: Path) -> None:
+        """save() creates state directory if needed."""
+        store = PlexSyncStateStore(tmp_path)
+        store.mark_synced("nhl", "fp123")
+        store.save()
+
+        assert (tmp_path / "state" / "plex-sync-state.json").exists()
+
+    def test_save_skipped_if_not_dirty(self, tmp_path: Path) -> None:
+        """save() does nothing if state not dirty."""
+        store = PlexSyncStateStore(tmp_path)
+        store.save()
+        # File shouldn't exist since nothing was modified
+        assert not (tmp_path / "state" / "plex-sync-state.json").exists()
+
+    def test_file_format(self, tmp_path: Path) -> None:
+        """Verify the JSON file format."""
+        store = PlexSyncStateStore(tmp_path)
+        store.mark_synced("nhl", "fp123", shows=1, seasons=2, episodes=10)
+        store.save()
+
+        with (tmp_path / "state" / "plex-sync-state.json").open() as f:
+            data = json.load(f)
+
+        assert "sports" in data
+        assert "nhl" in data["sports"]
+        assert data["sports"]["nhl"]["fingerprint"] == "fp123"
+        assert data["sports"]["nhl"]["shows_synced"] == 1
+        assert data["sports"]["nhl"]["seasons_synced"] == 2
+        assert data["sports"]["nhl"]["episodes_synced"] == 10
+        assert "synced_at" in data["sports"]["nhl"]
+


### PR DESCRIPTION
- Updated `playbook.sample.yaml` to clarify Plex metadata sync triggers and first-time sync behavior.
- Improved `operations.md` to detail the conditions under which Plex sync occurs, including new file processing and metadata changes.
- Enhanced `plex_metadata_sync.py` to track sync state and determine sports needing sync based on metadata changes or initial sync requirements.
- Refactored `processor.py` to streamline the logic for determining when to run Plex sync, incorporating new sync state checks.