### PR TITLE
fix: update metadata extraction to prioritize new URL fields

### DIFF
--- a/src/playbook/plex_metadata_sync.py
+++ b/src/playbook/plex_metadata_sync.py
@@ -107,8 +107,8 @@ def _map_show_metadata(show: Show, base_url: str) -> MappedMetadata:
             _first(meta, ("originally_available", "originally_available_at"))
         ),
         summary=show.summary or meta.get("summary"),
-        poster_url=_resolve_asset_url(base_url, _first(meta, ("poster", "thumb", "cover"))),
-        background_url=_resolve_asset_url(base_url, _first(meta, ("background", "art", "fanart"))),
+        poster_url=_resolve_asset_url(base_url, _first(meta, ("url_poster", "poster", "thumb", "cover"))),
+        background_url=_resolve_asset_url(base_url, _first(meta, ("url_background", "background", "art", "fanart"))),
     )
 
 
@@ -123,8 +123,8 @@ def _map_season_metadata(season: Season, base_url: str) -> MappedMetadata:
             _first(meta, ("originally_available", "originally_available_at"))
         ),
         summary=season.summary or meta.get("summary"),
-        poster_url=_resolve_asset_url(base_url, _first(meta, ("poster", "thumb", "cover"))),
-        background_url=_resolve_asset_url(base_url, _first(meta, ("background", "art", "fanart"))),
+        poster_url=_resolve_asset_url(base_url, _first(meta, ("url_poster", "poster", "thumb", "cover"))),
+        background_url=_resolve_asset_url(base_url, _first(meta, ("url_background", "background", "art", "fanart"))),
     )
 
 
@@ -140,8 +140,8 @@ def _map_episode_metadata(episode: Episode, base_url: str) -> MappedMetadata:
             or episode.originally_available
         ),
         summary=episode.summary or meta.get("summary"),
-        poster_url=_resolve_asset_url(base_url, _first(meta, ("poster", "thumb", "cover"))),
-        background_url=_resolve_asset_url(base_url, _first(meta, ("background", "art", "fanart"))),
+        poster_url=_resolve_asset_url(base_url, _first(meta, ("url_poster", "poster", "thumb", "cover"))),
+        background_url=_resolve_asset_url(base_url, _first(meta, ("url_background", "background", "art", "fanart"))),
     )
 
 

--- a/tests/test_plex_metadata_sync.py
+++ b/tests/test_plex_metadata_sync.py
@@ -294,6 +294,22 @@ class TestMapSeasonMetadata:
         assert result.summary == "The 2024 racing season"
         assert result.poster_url == "http://absolute.com/poster.jpg"
 
+    def test_url_poster_field_preferred(self) -> None:
+        """Test that url_poster (used by meta-manager YAMLs) is extracted."""
+        season = _make_season(
+            index=1,
+            title="NHL Week 1",
+            summary="Week 1 of NHL season",
+            metadata={
+                "url_poster": "https://example.com/posters/nhl/s1/poster.jpg",
+                "url_background": "https://example.com/posters/nhl/s1/background.jpg",
+            },
+        )
+        result = _map_season_metadata(season, "http://cdn.example.com")
+
+        assert result.poster_url == "https://example.com/posters/nhl/s1/poster.jpg"
+        assert result.background_url == "https://example.com/posters/nhl/s1/background.jpg"
+
 
 class TestMapEpisodeMetadata:
     def test_extracts_basic_fields(self) -> None:


### PR DESCRIPTION
- Modified `plex_metadata_sync.py` to prefer `url_poster` and `url_background` fields for poster and background URLs when mapping show, season, and episode metadata.
- Added a test in `test_plex_metadata_sync.py` to verify the correct extraction of these new fields, ensuring compatibility with meta-manager YAMLs.