### PR TITLE
refactor: update search_show method to return None for unmatched results

### DIFF
--- a/src/playbook/plex_client.py
+++ b/src/playbook/plex_client.py
@@ -341,7 +341,7 @@ class PlexClient:
             if entry_title.lower() == target_lower:
                 return entry
 
-        # Second pass: fuzzy match (normalized)
+        # Second pass: fuzzy match (normalized - removes hyphens/spaces/underscores)
         for entry in all_entries:
             entry_title = str(entry.get("title", ""))
             if normalize(entry_title) == target_normalized:
@@ -352,8 +352,17 @@ class PlexClient:
                 )
                 return entry
 
-        # Fall back to first result if any
-        return all_entries[0] if all_entries else None
+        # Log what we found but couldn't match
+        if all_entries:
+            found_titles = [e.get("title", "?") for e in all_entries[:5]]
+            LOGGER.debug(
+                "No match for '%s' among Plex results: %s",
+                title,
+                found_titles,
+            )
+
+        # No match found - don't return unrelated results
+        return None
 
     def get_metadata(self, rating_key: str) -> Optional[Dict[str, Any]]:
         """Get full metadata for an item by rating key."""

--- a/tests/test_plex_client.py
+++ b/tests/test_plex_client.py
@@ -226,8 +226,8 @@ class TestSearchShowFuzzyMatching:
             assert result is not None
             assert result["ratingKey"] == "300"
 
-    def test_no_match_returns_first_result(self) -> None:
-        """When no fuzzy match, return first search result."""
+    def test_no_match_returns_none(self) -> None:
+        """When no fuzzy match, return None (don't return unrelated shows)."""
         client = PlexClient("http://localhost:32400", "token")
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -241,9 +241,8 @@ class TestSearchShowFuzzyMatching:
 
         with patch.object(client.session, "request", return_value=mock_response):
             result = client.search_show("1", "NHL 2025-2026")
-            # Should return first result as fallback
-            assert result is not None
-            assert result["ratingKey"] == "999"
+            # Should NOT return unrelated shows - prevents Formula 1 matching Formula E
+            assert result is None
 
     def test_empty_results_returns_none(self) -> None:
         """Empty search results return None."""


### PR DESCRIPTION
- Modified the `search_show` method in `plex_client.py` to log unmatched search results and return None instead of the first result, preventing unrelated matches.
- Updated the corresponding test in `test_plex_client.py` to reflect this change, ensuring that no unrelated shows are returned when no fuzzy match is found.