### PR TITLE
chore: release v2.19.2 — security patches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "playbook"
-version = "2.19.1"
+version = "2.19.2"
 description = "Automated file matching, renaming, and metadata for sports content in Plex"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- **Security**: Bump `requests` 2.32.5 → 2.33.1 (CVE-2026-25645 — predictable temp file path)
- **Dependencies**: Bump `nicegui` 3.8.0 → 3.9.0, `docker/setup-buildx-action` 3 → 4
- **CI**: Fix trivy-action tag, ruff exclude for `.claude/`, format fix

## Test plan
- [x] All CI checks passing on merged Dependabot PRs
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)