### PR TITLE
ci: build multi-arch Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -92,6 +92,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -111,6 +116,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             GIT_SHA=${{ env.GIT_SHA }}
             GIT_BRANCH=${{ env.GIT_BRANCH }}


### PR DESCRIPTION
## Summary
- Fixes #151 — ARM64 users got `no matching manifest for linux/arm64/v8` when pulling `ghcr.io/s0len/playbook`.
- Root cause: `docker/build-push-action` had no `platforms:` field, so Buildx defaulted to the runner's architecture (amd64-only manifest).
- Adds `docker/setup-qemu-action@v3` and `platforms: linux/amd64,linux/arm64` so the published image is multi-arch.

## Notes
- arm64 build is QEMU-emulated on the amd64 runner — expect the `build-and-push` job to take noticeably longer (roughly +5–10 min).
- The Trivy scan job is unchanged and continues to scan the amd64 image only; that's fine since the base image and Python deps are identical across arches and `pip-audit` covers the deps.

## Test plan
- [ ] Watch the CI run on this PR / after merge to `develop`; confirm both `linux/amd64` and `linux/arm64` show in the pushed manifest (`docker buildx imagetools inspect ghcr.io/s0len/playbook:develop`).
- [ ] Confirm `docker compose pull` succeeds on an arm64 host.
- [ ] If `pip install --require-hashes` fails on the arm64 stage, regenerate `requirements.lock` so it includes arm64 wheel hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)