### PR TITLE
release: 2.20.0 (multi-arch Docker + dependency updates)

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -92,6 +92,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -111,6 +116,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             GIT_SHA=${{ env.GIT_SHA }}
             GIT_BRANCH=${{ env.GIT_BRANCH }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.20.0] - 2026-04-25
+
+### Added
+- Multi-arch Docker images: `ghcr.io/s0len/playbook` is now published for both `linux/amd64` and `linux/arm64` (fixes #151).
+
+### Changed
+- Dependency updates: `rapidfuzz` 3.14.5, `nicegui` 3.10.0, `rich` 15.0.0, `browser-use` >=0.12.6.
+- Dev dependency updates: `pytest` >=9.0.3, `pre-commit` >=4.5.1, `setuptools` >=82.0.1, `mkdocs-material` >=9.7.6.
+- CI: `aquasecurity/trivy-action` 0.36.0, `softprops/action-gh-release` v3.
+
 ## [2.7.0] - 2026-02-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "playbook"
-version = "2.19.2"
+version = "2.20.0"
 description = "Automated file matching, renaming, and metadata for sports content in Plex"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Promotes `develop` to `main` for the 2.20.0 release.
- Multi-arch Docker images (`linux/amd64` + `linux/arm64`) — fixes #151.
- Bundles dependency bumps already merged into `main` (rapidfuzz, nicegui, rich, browser-use, pytest, pre-commit, setuptools, mkdocs-material) plus CI action bumps (trivy-action, action-gh-release).

## Test plan
- [ ] Tag `v2.20.0` after merge; confirm `build-and-push` job pushes a multi-arch manifest.
- [ ] `docker buildx imagetools inspect ghcr.io/s0len/playbook:2.20.0` shows both amd64 and arm64.
- [ ] `docker compose pull` succeeds on an arm64 host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)