### PR TITLE
fix(gui): preserve root file handler under uvicorn (silent logger bug)

### DIFF
--- a/src/playbook/gui/app.py
+++ b/src/playbook/gui/app.py
@@ -266,6 +266,10 @@ def run_with_gui(
         reload=False,
         show=False,  # Don't auto-open browser
         storage_secret="playbook-gui-storage",  # Enable persistent user storage
+        # Skip uvicorn's dictConfig — it calls _clearExistingHandlers() which closes
+        # our FileHandler. Combined with mode='w', the handler refuses to reopen and
+        # silently drops every record after this call. See cli.configure_logging.
+        log_config=None,
     )
 
 
@@ -336,6 +340,7 @@ def run_gui_standalone(port: int = 8765, host: str = "0.0.0.0") -> None:
         reload=True,
         show=True,
         storage_secret="playbook-gui-storage",  # Enable persistent user storage
+        log_config=None,  # See run_with_gui — preserves our root file handler.
     )
 
 


### PR DESCRIPTION
## Summary
Production `/tmp/playbook.log` stopped writing immediately after the boot banner, while stdout kept flowing — making the GUI deployment effectively unobservable. Root cause: uvicorn's `Config.configure_logging()` calls `logging.config.dictConfig()` with its default `LOGGING_CONFIG`. In non-incremental mode `dictConfig` unconditionally calls `_clearExistingHandlers()`, which `close()`s every existing handler. Our `FileHandler` was opened with `mode='w'`, and `FileHandler.emit()` then refuses to reopen (check: `self.mode != 'w' or not self._closed`). The handler stays attached to `root_logger.handlers` but silently swallows every subsequent record. The console `StreamHandler` survives because it wraps `sys.stderr` and `Handler.close()` doesn't touch the underlying stream — that's why stdout looked healthy.

Repro confirms it:
```
FileHandler.stream = None
FileHandler._closed = True
FileHandler in root.handlers = True
```
With `log_config=None` passed to `ui.run` (forwarded by NiceGUI's `**kwargs` straight into `uvicorn.Config`), uvicorn skips `dictConfig` (`uvicorn/config.py:367`) and our handlers stay alive. Verified by re-running the same repro: both before/after log lines now reach the file.

## Diagnostic data from the live pod
- `/proc/1/fd/` had **no** entry for `/tmp/playbook.log` despite the process running 22 days
- `/tmp/playbook.log` frozen at 9 lines, last one being `Starting Playbook GUI on http://0.0.0.0:8765` (immediately before `ui.run()`)
- stdout last 24h: 100% `watchdog.observers.inotify_buffer` DEBUG noise — formatted with **our** `LOG_RECORD_FORMAT`, proving the console handler kept working

## Side effects
Skipping `dictConfig` means uvicorn's named loggers (`uvicorn`, `uvicorn.error`, `uvicorn.access`) don't get their packaged handlers. They default to `propagate=True`, so their records flow to root and into our file/console handlers — desirable, since uvicorn access/error logs now appear in `playbook.log`.

## Test plan
- [x] Repro both bug and fix locally — confirmed
- [x] Full pytest suite (1407 tests) passes
- [x] Ruff clean
- [ ] Deploy to cluster: confirm `/tmp/playbook.log` continues to grow past boot banner and `LOGGER.info("Starting file watcher in background thread")` is captured
- [ ] Confirm stdout no longer drops `playbook.*` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)