### PR TITLE
release: 2.20.1 (silent logger fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.20.1] - 2026-04-25
+
+### Fixed
+- GUI logging: `playbook.*` log records were silently dropped from the file log shortly after startup. NiceGUI's `ui.run()` triggers uvicorn's `dictConfig`, which closes every existing handler; our `mode='w'` `FileHandler` then refused to reopen and silently swallowed every subsequent record. Pass `log_config=None` to `ui.run()` so uvicorn skips `dictConfig` and our root handlers survive.
+
 ## [2.20.0] - 2026-04-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "playbook"
-version = "2.20.0"
+version = "2.20.1"
 description = "Automated file matching, renaming, and metadata for sports content in Plex"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/playbook/gui/app.py
+++ b/src/playbook/gui/app.py
@@ -266,6 +266,10 @@ def run_with_gui(
         reload=False,
         show=False,  # Don't auto-open browser
         storage_secret="playbook-gui-storage",  # Enable persistent user storage
+        # Skip uvicorn's dictConfig — it calls _clearExistingHandlers() which closes
+        # our FileHandler. Combined with mode='w', the handler refuses to reopen and
+        # silently drops every record after this call. See cli.configure_logging.
+        log_config=None,
     )
 
 
@@ -336,6 +340,7 @@ def run_gui_standalone(port: int = 8765, host: str = "0.0.0.0") -> None:
         reload=True,
         show=True,
         storage_secret="playbook-gui-storage",  # Enable persistent user storage
+        log_config=None,  # See run_with_gui — preserves our root file handler.
     )
 
 


### PR DESCRIPTION
## Summary
Patch release for the production silent-logger bug. `playbook.*` records were silently dropped from the file log immediately after `ui.run()` started, because uvicorn's `dictConfig` closed our root `FileHandler` and `mode='w'` prevented it from reopening. Fix: pass `log_config=None` to `ui.run()` so uvicorn skips `dictConfig`.

Diagnosed live on the cluster pod (`/proc/1/fd/` had no fd to `/tmp/playbook.log` despite 22 days uptime), reproduced and fix verified locally.

## Test plan
- [x] Repro confirmed bug and fix
- [x] Full pytest suite (1407) passes
- [ ] Tag `v2.20.1` after merge; confirm `build-and-push` succeeds
- [ ] Roll new image to the cluster, verify `/tmp/playbook.log` grows past boot banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)