### PR TITLE
ci: auto-populate GitHub Release notes from CHANGELOG

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -126,12 +126,32 @@ jobs:
             ${{ startsWith(github.ref, 'refs/tags/v') && format('ghcr.io/s0len/playbook:{0}', env.VERSION) || '' }}
             ${{ startsWith(github.ref, 'refs/tags/v') && 'ghcr.io/s0len/playbook:latest' || '' }}
 
+      - name: Extract release notes from CHANGELOG
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          {
+            awk -v ver="${VERSION}" '
+              $0 ~ "^## \\["ver"\\]" { found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' CHANGELOG.md
+            echo
+            echo "## Docker"
+            echo '```'
+            echo "docker pull ghcr.io/s0len/playbook:${VERSION}"
+            echo '```'
+            echo "Image published for \`linux/amd64\` and \`linux/arm64\`."
+          } > /tmp/release-notes.md
+          echo "--- Generated release notes ---"
+          cat /tmp/release-notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
+          body_path: /tmp/release-notes.md
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Summary
The release-creation step in `build-and-push.yml` was creating GitHub Releases with empty bodies — v2.20.0 and v2.20.1 both needed manual notes pasted in after the fact. This adds a step that extracts the matching `## [VERSION]` section from `CHANGELOG.md` on tag push, appends a Docker pull footer, and feeds it to `action-gh-release` via `body_path`.

Tested the awk extraction locally against both v2.20.0 and v2.20.1 entries — produces clean output. If a future tag is pushed without a corresponding CHANGELOG entry, the release page will just have the Docker footer (graceful fallback, same surface area as today minus the pull instructions).

## Test plan
- [ ] After merge, the next release tag should produce a populated release page automatically — no manual `gh release edit` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)