### PR TITLE
feat(plex-sync): local fallback artwork when TVSportsDB has none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Added
+- Plex metadata sync: new `fallback_assets_dir` option (`integrations.plex.metadata_sync`) for local fallback artwork. When TVSportsDB has no poster/background for a show, season, or episode, Playbook uploads a matching local image (`<dir>/<show_slug>/poster.jpg`, `season-NN.jpg`, `sNNeNN.jpg`) to Plex instead of leaving the generic show poster. API artwork always takes precedence (fixes #181).
+
 ## [2.20.3] - 2026-05-16
 
 ### Fixed

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -44,6 +44,9 @@ settings:
         enabled: false
         timeout: 15
         scan_wait: 5
+        # Local artwork used when TVSportsDB has no poster/background.
+        # Layout: <dir>/<show_slug>/poster.jpg, season-03.jpg, s03e02.jpg
+        # fallback_assets_dir: /config/assets
 
       # Trigger Plex library scan when files are linked
       scan_on_activity:

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -47,6 +47,41 @@ settings:
 3. **First-time sync** - Sports that have never been synced will auto-sync on first run
 4. **Field locking** - Locks Plex fields after updating to prevent metadata refresh from overwriting
 
+### Fallback Artwork
+
+Some events have no artwork in TVSportsDB yet (`url_poster: null`). By default Playbook leaves
+those items untouched, so Plex falls back to the generic show poster for the season. To fill the
+gaps with your own artwork, point `fallback_assets_dir` at a directory of local images:
+
+```yaml
+settings:
+  integrations:
+    plex:
+      metadata_sync:
+        enabled: true
+        fallback_assets_dir: /config/assets
+```
+
+Files are matched per show slug (the same `show_slug` as in the sport config):
+
+```
+/config/assets/
+  ufc-2026/
+    poster.jpg        # Show poster
+    background.jpg    # Show background
+    season-03.jpg     # Poster for season 3 (season-3.jpg also works)
+    s03e02.jpg        # Poster for season 3, episode 2
+```
+
+Supported extensions: `.jpg`, `.jpeg`, `.png`, `.webp`.
+
+Local files are a **fallback only** - artwork from TVSportsDB always takes precedence, so
+once real artwork is uploaded upstream it replaces the local fallback on the next sync.
+Because syncs are fingerprint-based, artwork added for an *already synced* item is applied
+on the next forced sync (`force: true` or `PLEX_FORCE=1`). The cleanest long-term fix is
+still to upload proper artwork to [tvsportsdb.com](https://tvsportsdb.com) so everyone
+benefits.
+
 ### Environment Variables
 
 | Variable | Purpose |
@@ -59,6 +94,7 @@ settings:
 | `PLEX_FORCE` | Force all updates |
 | `PLEX_SYNC_DRY_RUN` | Dry-run mode |
 | `PLEX_SPORTS` | Comma-separated sport IDs to sync |
+| `PLEX_SYNC_FALLBACK_ASSETS_DIR` | Local fallback artwork directory |
 
 ### Relationship with Kometa
 

--- a/src/playbook/config.py
+++ b/src/playbook/config.py
@@ -65,6 +65,7 @@ class PlexMetadataSyncSettings:
     sports: list[str] = field(default_factory=list)
     scan_wait: float = 5.0  # Seconds to wait after triggering library scan
     lock_poster_fields: bool = False  # Whether to lock poster fields to prevent updates
+    fallback_assets_dir: str | None = None  # Local artwork used when TVSportsDB has none
 
 
 @dataclass
@@ -1142,6 +1143,11 @@ def _build_plex_metadata_sync_settings(data: dict[str, Any]) -> PlexMetadataSync
 
     sports = _ensure_string_list(data.get("sports"), field_name="integrations.plex.metadata_sync.sports")
 
+    fallback_assets_dir_raw = data.get("fallback_assets_dir")
+    if fallback_assets_dir_raw is not None and not isinstance(fallback_assets_dir_raw, str):
+        raise ValueError("'integrations.plex.metadata_sync.fallback_assets_dir' must be a string path")
+    fallback_assets_dir = fallback_assets_dir_raw or None
+
     return PlexMetadataSyncSettings(
         enabled=bool(data.get("enabled", False)),
         timeout=timeout,
@@ -1150,6 +1156,7 @@ def _build_plex_metadata_sync_settings(data: dict[str, Any]) -> PlexMetadataSync
         sports=sports,
         scan_wait=scan_wait,
         lock_poster_fields=bool(data.get("lock_poster_fields", False)),
+        fallback_assets_dir=fallback_assets_dir,
     )
 
 

--- a/src/playbook/gui/components/settings/integrations/plex_editor.py
+++ b/src/playbook/gui/components/settings/integrations/plex_editor.py
@@ -115,6 +115,13 @@ _SECTIONS = [
                 "description": "Prevent Plex from overwriting posters",
             },
             {
+                "key": "metadata_sync.fallback_assets_dir",
+                "label": "Fallback Assets Directory",
+                "type": "text",
+                "description": "Local artwork used when TVSportsDB has none (e.g. /config/assets)",
+                "placeholder": "/config/assets",
+            },
+            {
                 "key": "metadata_sync.sports",
                 "label": "Sports Filter",
                 "type": "list",

--- a/src/playbook/local_assets.py
+++ b/src/playbook/local_assets.py
@@ -1,0 +1,93 @@
+"""Local fallback artwork for Plex metadata sync.
+
+Resolves user-provided poster/background files from a configured assets
+directory. These are used as a *fallback* when TVSportsDB has no artwork
+for an item (``url_poster: null``) - real artwork from the API always wins.
+
+Directory layout (relative to the configured ``fallback_assets_dir``):
+
+    <show_slug>/poster.jpg          Show poster
+    <show_slug>/background.jpg      Show background
+    <show_slug>/season-03.jpg       Poster for season 3 (unpadded also works)
+    <show_slug>/s03e02.jpg          Poster for season 3, episode 2
+
+``<show_slug>`` is the TVSportsDB show slug (e.g. ``ufc-2026``), the same
+value as ``show_slug`` in the sport config. Supported image extensions:
+jpg, jpeg, png, webp.
+"""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import Episode, Season, Show
+
+LOGGER = logging.getLogger(__name__)
+
+IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png", ".webp")
+
+
+def asset_content_type(path: Path) -> str:
+    """Return the MIME type for an image file, defaulting to JPEG."""
+    content_type, _ = mimetypes.guess_type(path.name)
+    return content_type or "image/jpeg"
+
+
+def _season_number(season: Season) -> int | None:
+    if season.display_number is not None:
+        return season.display_number
+    return season.index
+
+
+def _episode_number(episode: Episode) -> int | None:
+    if episode.display_number is not None:
+        return episode.display_number
+    return episode.index
+
+
+class LocalAssetResolver:
+    """Looks up local fallback artwork files for shows, seasons, and episodes."""
+
+    def __init__(self, assets_dir: str | Path | None) -> None:
+        self.assets_dir = Path(assets_dir) if assets_dir else None
+        if self.assets_dir and not self.assets_dir.is_dir():
+            LOGGER.warning("Fallback assets directory does not exist: %s", self.assets_dir)
+
+    @property
+    def enabled(self) -> bool:
+        return self.assets_dir is not None
+
+    def _find(self, show: Show, stems: list[str]) -> Path | None:
+        """Return the first existing image file matching any stem for the show."""
+        if not self.assets_dir or not show.key:
+            return None
+        show_dir = self.assets_dir / show.key
+        for stem in stems:
+            for ext in IMAGE_EXTENSIONS:
+                candidate = show_dir / f"{stem}{ext}"
+                if candidate.is_file():
+                    return candidate
+        return None
+
+    def show_poster(self, show: Show) -> Path | None:
+        return self._find(show, ["poster"])
+
+    def show_background(self, show: Show) -> Path | None:
+        return self._find(show, ["background"])
+
+    def season_poster(self, show: Show, season: Season) -> Path | None:
+        number = _season_number(season)
+        if number is None:
+            return None
+        return self._find(show, [f"season-{number:02d}", f"season-{number}"])
+
+    def episode_poster(self, show: Show, season: Season, episode: Episode) -> Path | None:
+        season_number = _season_number(season)
+        episode_number = _episode_number(episode)
+        if season_number is None or episode_number is None:
+            return None
+        return self._find(show, [f"s{season_number:02d}e{episode_number:02d}"])

--- a/src/playbook/plex_client.py
+++ b/src/playbook/plex_client.py
@@ -506,6 +506,34 @@ class PlexClient:
         self._request("PUT", f"/library/metadata/{rating_key}/{element}", params=params)
         return True
 
+    def upload_asset(self, rating_key: str, element: str, data: bytes, *, content_type: str = "image/jpeg") -> bool:
+        """Upload an artwork asset (poster/thumb, art/background) from raw image bytes.
+
+        Unlike set_asset, this pushes a local image directly to Plex instead of
+        having Plex download it from a URL.
+
+        Args:
+            rating_key: The Plex rating key of the item.
+            element: Asset type - use 'thumb' for poster, 'art' for background.
+            data: Raw image bytes.
+            content_type: MIME type of the image (e.g. 'image/jpeg', 'image/png').
+
+        Returns:
+            True if successful.
+        """
+        endpoints = {"thumb": "posters", "art": "arts"}
+        endpoint = endpoints.get(element)
+        if endpoint is None:
+            raise PlexApiError(f"Invalid asset element '{element}'; valid: {set(endpoints)}")
+
+        self._request(
+            "POST",
+            f"/library/metadata/{rating_key}/{endpoint}",
+            headers={"Content-Type": content_type},
+            data=data,
+        )
+        return True
+
     def refresh_metadata(self, rating_key: str) -> None:
         """Trigger a metadata refresh for an item."""
         self._request("PUT", f"/library/metadata/{rating_key}/refresh")

--- a/src/playbook/plex_metadata_sync.py
+++ b/src/playbook/plex_metadata_sync.py
@@ -31,6 +31,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 from .config import AppConfig, SportConfig
+from .local_assets import LocalAssetResolver, asset_content_type
 from .metadata import (
     MetadataChangeResult,
     MetadataFingerprintStore,
@@ -65,6 +66,9 @@ class MappedMetadata:
     summary: str | None
     poster_url: str | None
     background_url: str | None
+    # Local fallback artwork, uploaded when the API provides no URL
+    poster_file: Path | None = None
+    background_file: Path | None = None
 
 
 def _as_int(value: object) -> int | None:
@@ -427,27 +431,31 @@ def _apply_metadata(
                 stats.errors.append(f"Metadata update failed: {' | '.join(context_parts)}: {exc}")
 
     # Handle assets: poster -> 'thumb', background -> 'art'
+    # A URL from the API takes precedence; a local fallback file is uploaded
+    # only when the API provided no artwork.
     asset_mappings = [
-        ("poster_url", "thumb", "poster"),
-        ("background_url", "art", "background"),
+        ("poster_url", "poster_file", "thumb", "poster"),
+        ("background_url", "background_file", "art", "background"),
     ]
-    for attr, element, display_name in asset_mappings:
-        asset_url = getattr(mapped, attr)
-        if not asset_url:
+    for url_attr, file_attr, element, display_name in asset_mappings:
+        asset_url = getattr(mapped, url_attr)
+        asset_file: Path | None = getattr(mapped, file_attr)
+        if not asset_url and not asset_file:
             LOGGER.debug("No %s URL found for %s (%s)", display_name, label, rating_key)
             continue
 
+        asset_source = asset_url or str(asset_file)
         LOGGER.debug(
-            "Attempting to set %s for %s (key=%s): url=%s, element=%s",
+            "Attempting to set %s for %s (key=%s): source=%s, element=%s",
             display_name,
             label,
             rating_key,
-            asset_url,
+            asset_source,
             element,
         )
 
         if dry_run:
-            LOGGER.debug("Dry-run: would set %s %s %s to %s", label, rating_key, display_name, asset_url)
+            LOGGER.debug("Dry-run: would set %s %s %s to %s", label, rating_key, display_name, asset_source)
         else:
             try:
                 # Unlock field before upload to ensure Plex accepts the update
@@ -456,7 +464,16 @@ def _apply_metadata(
                 stats.api_calls += 1
 
                 # Upload the asset
-                client.set_asset(rating_key, element, asset_url)
+                if asset_url:
+                    client.set_asset(rating_key, element, asset_url)
+                else:
+                    assert asset_file is not None
+                    client.upload_asset(
+                        rating_key,
+                        element,
+                        asset_file.read_bytes(),
+                        content_type=asset_content_type(asset_file),
+                    )
                 LOGGER.debug("Successfully set %s for %s (key=%s)", display_name, label, rating_key)
                 stats.assets_updated += 1
                 stats.api_calls += 1
@@ -467,7 +484,7 @@ def _apply_metadata(
                 stats.api_calls += 1
 
                 updated = True
-            except PlexApiError as exc:
+            except (PlexApiError, OSError) as exc:
                 LOGGER.error("Failed to set %s for %s (key=%s): %s", display_name, label, rating_key, exc)
                 stats.assets_failed += 1
                 # Build error with actionable context
@@ -476,8 +493,8 @@ def _apply_metadata(
                     context_parts.append(f"library={library_id}")
                 if metadata_url:
                     context_parts.append(f"source={metadata_url}")
-                if asset_url:
-                    context_parts.append(f"asset_url={asset_url}")
+                if asset_source:
+                    context_parts.append(f"asset_source={asset_source}")
                 stats.errors.append(f"Asset update failed: {' | '.join(context_parts)}: {exc}")
 
     return updated
@@ -536,6 +553,10 @@ class PlexMetadataSync:
 
         default_scan_wait = plex_sync_cfg.scan_wait if plex_sync_cfg.scan_wait != 5.0 else legacy_cfg.scan_wait
         self.scan_wait = scan_wait if scan_wait is not None else default_scan_wait
+
+        # Local fallback artwork, used when the API has none: env > config
+        fallback_assets_dir = os.getenv("PLEX_SYNC_FALLBACK_ASSETS_DIR") or plex_sync_cfg.fallback_assets_dir
+        self.asset_resolver = LocalAssetResolver(fallback_assets_dir)
 
         self._client: PlexClient | None = None
         self._library_id_resolved: str | None = None
@@ -914,6 +935,11 @@ class PlexMetadataSync:
             return
 
         mapped = _map_show_metadata(show, base_url)
+        if self.asset_resolver.enabled:
+            if not mapped.poster_url:
+                mapped.poster_file = self.asset_resolver.show_poster(show)
+            if not mapped.background_url:
+                mapped.background_file = self.asset_resolver.show_background(show)
         # Apply metadata with lock_fields=True to preserve original title casing
         if _apply_metadata(
             self.client,
@@ -993,6 +1019,8 @@ class PlexMetadataSync:
 
             if season_id in seasons_to_update:
                 mapped = _map_season_metadata(season, base_url)
+                if self.asset_resolver.enabled and not mapped.poster_url:
+                    mapped.poster_file = self.asset_resolver.season_poster(show, season)
                 if _apply_metadata(
                     self.client,
                     rating_key,
@@ -1083,6 +1111,8 @@ class PlexMetadataSync:
                     continue
 
                 mapped = _map_episode_metadata(episode, base_url)
+                if self.asset_resolver.enabled and not mapped.poster_url:
+                    mapped.poster_file = self.asset_resolver.episode_poster(show, season, episode)
                 if _apply_metadata(
                     self.client,
                     episode_rating,

--- a/tests/test_local_assets.py
+++ b/tests/test_local_assets.py
@@ -1,0 +1,298 @@
+"""Tests for local fallback artwork resolution and upload."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from playbook.local_assets import LocalAssetResolver, asset_content_type
+from playbook.models import Episode, Season, Show
+from playbook.plex_client import PLEX_TYPE_SEASON, PlexSyncStats
+from playbook.plex_metadata_sync import MappedMetadata, _apply_metadata
+
+
+def _make_show(key: str = "ufc-2026") -> Show:
+    return Show(key=key, title="UFC 2026", summary=None, seasons=[])
+
+
+def _make_season(index: int = 3, display_number: int | None = 3) -> Season:
+    return Season(
+        key=str(index),
+        title=f"Season {index}",
+        summary=None,
+        index=index,
+        episodes=[],
+        display_number=display_number,
+    )
+
+
+def _make_episode(index: int = 2, display_number: int | None = 2) -> Episode:
+    return Episode(
+        title=f"Episode {index}",
+        summary=None,
+        originally_available=None,
+        index=index,
+        display_number=display_number,
+    )
+
+
+class TestAssetContentType:
+    def test_jpg(self) -> None:
+        assert asset_content_type(Path("poster.jpg")) == "image/jpeg"
+
+    def test_png(self) -> None:
+        assert asset_content_type(Path("poster.png")) == "image/png"
+
+    def test_webp(self) -> None:
+        assert asset_content_type(Path("poster.webp")) == "image/webp"
+
+    def test_unknown_defaults_to_jpeg(self) -> None:
+        assert asset_content_type(Path("poster.unknown")) == "image/jpeg"
+
+
+class TestLocalAssetResolver:
+    def test_disabled_without_dir(self) -> None:
+        resolver = LocalAssetResolver(None)
+        assert resolver.enabled is False
+        assert resolver.show_poster(_make_show()) is None
+
+    def test_enabled_with_dir(self, tmp_path: Path) -> None:
+        assert LocalAssetResolver(tmp_path).enabled is True
+
+    def test_show_poster_and_background(self, tmp_path: Path) -> None:
+        show_dir = tmp_path / "ufc-2026"
+        show_dir.mkdir()
+        (show_dir / "poster.jpg").write_bytes(b"poster")
+        (show_dir / "background.png").write_bytes(b"background")
+
+        resolver = LocalAssetResolver(tmp_path)
+        assert resolver.show_poster(_make_show()) == show_dir / "poster.jpg"
+        assert resolver.show_background(_make_show()) == show_dir / "background.png"
+
+    def test_season_poster_zero_padded(self, tmp_path: Path) -> None:
+        show_dir = tmp_path / "ufc-2026"
+        show_dir.mkdir()
+        (show_dir / "season-03.jpg").write_bytes(b"season")
+
+        resolver = LocalAssetResolver(tmp_path)
+        assert resolver.season_poster(_make_show(), _make_season(3)) == show_dir / "season-03.jpg"
+
+    def test_season_poster_unpadded(self, tmp_path: Path) -> None:
+        show_dir = tmp_path / "ufc-2026"
+        show_dir.mkdir()
+        (show_dir / "season-3.webp").write_bytes(b"season")
+
+        resolver = LocalAssetResolver(tmp_path)
+        assert resolver.season_poster(_make_show(), _make_season(3)) == show_dir / "season-3.webp"
+
+    def test_season_poster_uses_display_number(self, tmp_path: Path) -> None:
+        show_dir = tmp_path / "ufc-2026"
+        show_dir.mkdir()
+        (show_dir / "season-07.jpg").write_bytes(b"season")
+
+        resolver = LocalAssetResolver(tmp_path)
+        season = _make_season(index=1, display_number=7)
+        assert resolver.season_poster(_make_show(), season) == show_dir / "season-07.jpg"
+
+    def test_episode_poster(self, tmp_path: Path) -> None:
+        show_dir = tmp_path / "ufc-2026"
+        show_dir.mkdir()
+        (show_dir / "s03e02.jpg").write_bytes(b"episode")
+
+        resolver = LocalAssetResolver(tmp_path)
+        found = resolver.episode_poster(_make_show(), _make_season(3), _make_episode(2))
+        assert found == show_dir / "s03e02.jpg"
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        resolver = LocalAssetResolver(tmp_path)
+        assert resolver.show_poster(_make_show()) is None
+        assert resolver.season_poster(_make_show(), _make_season(3)) is None
+        assert resolver.episode_poster(_make_show(), _make_season(3), _make_episode(2)) is None
+
+    def test_other_show_dir_not_matched(self, tmp_path: Path) -> None:
+        other_dir = tmp_path / "nhl-2026"
+        other_dir.mkdir()
+        (other_dir / "season-03.jpg").write_bytes(b"season")
+
+        resolver = LocalAssetResolver(tmp_path)
+        assert resolver.season_poster(_make_show("ufc-2026"), _make_season(3)) is None
+
+
+class TestApplyMetadataWithLocalAssets:
+    def _mapped(self, **overrides: object) -> MappedMetadata:
+        defaults: dict[str, object] = {
+            "title": None,
+            "sort_title": None,
+            "original_title": None,
+            "originally_available_at": None,
+            "summary": None,
+            "poster_url": None,
+            "background_url": None,
+        }
+        defaults.update(overrides)
+        return MappedMetadata(**defaults)  # type: ignore[arg-type]
+
+    def test_local_poster_uploaded_when_no_url(self, tmp_path: Path) -> None:
+        poster = tmp_path / "season-03.jpg"
+        poster.write_bytes(b"image-bytes")
+
+        client = MagicMock()
+        stats = PlexSyncStats()
+        mapped = self._mapped(poster_file=poster)
+
+        updated = _apply_metadata(
+            client,
+            "12345",
+            mapped,
+            type_code=PLEX_TYPE_SEASON,
+            label="season 'Season 3'",
+            dry_run=False,
+            stats=stats,
+        )
+
+        assert updated is True
+        expected_calls = [
+            call.unlock_field("12345", "thumb"),
+            call.upload_asset("12345", "thumb", b"image-bytes", content_type="image/jpeg"),
+            call.lock_field("12345", "thumb"),
+        ]
+        assert client.mock_calls[-3:] == expected_calls
+        client.set_asset.assert_not_called()
+        assert stats.assets_updated == 1
+        assert stats.assets_failed == 0
+
+    def test_api_url_takes_precedence_over_local_file(self, tmp_path: Path) -> None:
+        poster = tmp_path / "poster.jpg"
+        poster.write_bytes(b"image-bytes")
+
+        client = MagicMock()
+        stats = PlexSyncStats()
+        mapped = self._mapped(poster_url="https://example.com/poster.jpg", poster_file=poster)
+
+        _apply_metadata(
+            client,
+            "12345",
+            mapped,
+            type_code=PLEX_TYPE_SEASON,
+            label="season 'Season 3'",
+            dry_run=False,
+            stats=stats,
+        )
+
+        client.set_asset.assert_called_once_with("12345", "thumb", "https://example.com/poster.jpg")
+        client.upload_asset.assert_not_called()
+
+    def test_no_artwork_leaves_item_untouched(self) -> None:
+        client = MagicMock()
+        stats = PlexSyncStats()
+
+        updated = _apply_metadata(
+            client,
+            "12345",
+            self._mapped(),
+            type_code=PLEX_TYPE_SEASON,
+            label="season 'Season 3'",
+            dry_run=False,
+            stats=stats,
+        )
+
+        assert updated is False
+        client.unlock_field.assert_not_called()
+        client.set_asset.assert_not_called()
+        client.upload_asset.assert_not_called()
+        assert stats.assets_updated == 0
+
+    def test_dry_run_does_not_upload(self, tmp_path: Path) -> None:
+        poster = tmp_path / "poster.jpg"
+        poster.write_bytes(b"image-bytes")
+
+        client = MagicMock()
+        stats = PlexSyncStats()
+
+        _apply_metadata(
+            client,
+            "12345",
+            self._mapped(poster_file=poster),
+            type_code=PLEX_TYPE_SEASON,
+            label="season 'Season 3'",
+            dry_run=True,
+            stats=stats,
+        )
+
+        client.upload_asset.assert_not_called()
+        client.unlock_field.assert_not_called()
+
+    def test_unreadable_file_counts_as_failure(self, tmp_path: Path) -> None:
+        client = MagicMock()
+        stats = PlexSyncStats()
+        mapped = self._mapped(poster_file=tmp_path / "missing.jpg")
+
+        _apply_metadata(
+            client,
+            "12345",
+            mapped,
+            type_code=PLEX_TYPE_SEASON,
+            label="season 'Season 3'",
+            dry_run=False,
+            stats=stats,
+        )
+
+        client.upload_asset.assert_not_called()
+        assert stats.assets_failed == 1
+        assert stats.errors
+
+
+class TestSyncShowFallbackWiring:
+    def test_sync_show_uploads_local_fallback_poster(self, tmp_path: Path) -> None:
+        """A show with no API artwork gets the local fallback uploaded during sync."""
+        from playbook.metadata import MetadataChangeResult
+        from playbook.plex_metadata_sync import PlexMetadataSync
+
+        show_dir = tmp_path / "ufc-2026"
+        show_dir.mkdir()
+        (show_dir / "poster.jpg").write_bytes(b"local-poster")
+
+        sync = object.__new__(PlexMetadataSync)
+        sync.force = True
+        sync.dry_run = False
+        sync.asset_resolver = LocalAssetResolver(tmp_path)
+        sync._library_id_resolved = None
+        sync._client = MagicMock()
+        sync._client.update_metadata.return_value = True
+
+        show = _make_show("ufc-2026")
+        show.metadata = {"url_poster": None}
+        stats = PlexSyncStats()
+
+        sync._sync_show(
+            show=show,
+            show_rating="12345",
+            base_url="https://api.tvsportsdb.com",
+            change=MetadataChangeResult(updated=True, changed_seasons=set(), changed_episodes={}),
+            is_first_sync=True,
+            stats=stats,
+        )
+
+        sync._client.upload_asset.assert_called_once_with("12345", "thumb", b"local-poster", content_type="image/jpeg")
+        assert stats.assets_updated == 1
+
+
+class TestFallbackAssetsConfig:
+    def test_default_is_none(self) -> None:
+        from playbook.config import PlexMetadataSyncSettings
+
+        assert PlexMetadataSyncSettings().fallback_assets_dir is None
+
+    def test_parsed_from_config(self) -> None:
+        from playbook.config import _build_plex_metadata_sync_settings
+
+        settings = _build_plex_metadata_sync_settings({"enabled": True, "fallback_assets_dir": "/config/assets"})
+        assert settings.fallback_assets_dir == "/config/assets"
+
+    def test_rejects_non_string(self) -> None:
+        from playbook.config import _build_plex_metadata_sync_settings
+
+        with pytest.raises(ValueError, match="fallback_assets_dir"):
+            _build_plex_metadata_sync_settings({"fallback_assets_dir": 123})

--- a/tests/test_plex_client.py
+++ b/tests/test_plex_client.py
@@ -124,6 +124,39 @@ class TestPlexClient:
             # art is the correct name for background
             client.set_asset("12345", "art", "http://example.com/bg.jpg")
 
+    def test_upload_asset_validates_element(self) -> None:
+        """Verify invalid asset element names are rejected for uploads."""
+        client = PlexClient("http://localhost:32400", "token")
+        with pytest.raises(PlexApiError, match="Invalid asset element"):
+            client.upload_asset("12345", "banner", b"image-bytes")
+
+    def test_upload_asset_posts_image_bytes(self) -> None:
+        """Verify upload_asset POSTs raw bytes to the correct endpoint."""
+        client = PlexClient("http://localhost:32400", "token")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(client.session, "request", return_value=mock_response) as mock_req:
+            client.upload_asset("12345", "thumb", b"image-bytes", content_type="image/png")
+
+            args, kwargs = mock_req.call_args
+            assert args[0] == "POST"
+            assert args[1].endswith("/library/metadata/12345/posters")
+            assert kwargs.get("data") == b"image-bytes"
+            assert kwargs.get("headers", {}).get("Content-Type") == "image/png"
+
+    def test_upload_asset_background_endpoint(self) -> None:
+        """Verify backgrounds go to the arts endpoint."""
+        client = PlexClient("http://localhost:32400", "token")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(client.session, "request", return_value=mock_response) as mock_req:
+            client.upload_asset("12345", "art", b"image-bytes")
+
+            args, _ = mock_req.call_args
+            assert args[1].endswith("/library/metadata/12345/arts")
+
     def test_unlock_field(self) -> None:
         """Verify unlock_field sends correct parameters."""
         client = PlexClient("http://localhost:32400", "token")


### PR DESCRIPTION
## Summary

Adds a `fallback_assets_dir` option to Plex metadata sync (`integrations.plex.metadata_sync`, env: `PLEX_SYNC_FALLBACK_ASSETS_DIR`). When TVSportsDB returns `url_poster: null` for a show, season, or episode, Playbook now looks for a local image and uploads it to Plex instead of leaving the generic show poster.

Closes #181

## How it works

- File layout matches the issue author's proposal:
  ```
  /config/assets/
    ufc-2026/            # show slug
      poster.jpg         # show poster
      background.jpg     # show background
      season-03.jpg      # season poster (season-3 also works)
      s03e02.jpg         # episode poster
  ```
- Supported extensions: jpg, jpeg, png, webp
- **Fallback only**: API artwork always takes precedence, so real posters uploaded to tvsportsdb.com replace local fallbacks on the next sync
- Uploads use a new `PlexClient.upload_asset()` (binary POST to `/library/metadata/{id}/posters` / `/arts`) with the same unlock → upload → lock flow as URL-based artwork
- New `LocalAssetResolver` module, GUI settings field, sample config + docs + changelog entries

## Notes

- Existing behavior is unchanged when `fallback_assets_dir` is unset (artwork step skipped on null, existing Plex posters untouched)
- Fingerprint-based sync means artwork added for an already-synced item applies on the next forced sync (`force: true` / `PLEX_FORCE=1`)

## Testing

- 22 new tests (resolver lookups, upload flow, URL precedence, dry-run, config parsing, sync wiring)
- Full suite: 1432 passed, ruff clean, sample config validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)