### PR TITLE
fix(gui): point NiceGUI storage at writable state dir

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -150,6 +150,12 @@ fi
 
 : "${DRY_RUN:=false}"
 
-export CONFIG_PATH SOURCE_DIR DESTINATION_DIR CACHE_DIR STATE_DIR DRY_RUN
+# NiceGUI persists app.storage (including GUI login sessions) to a directory it
+# resolves at import time, defaulting to ./.nicegui under the workdir (/app),
+# which the non-root user cannot create. Point it at the writable state volume
+# unless the operator set it explicitly.
+: "${NICEGUI_STORAGE_PATH:=${STATE_DIR}/.nicegui}"
+
+export CONFIG_PATH SOURCE_DIR DESTINATION_DIR CACHE_DIR STATE_DIR DRY_RUN NICEGUI_STORAGE_PATH
 
 exec python3 -m playbook.cli "$@"

--- a/src/playbook/gui/app.py
+++ b/src/playbook/gui/app.py
@@ -234,7 +234,10 @@ def run_with_gui(
 
     processor.notification_service.notify = _gui_notify
 
-    # Set NiceGUI storage path to persistent state directory
+    # Ensure the persistent NiceGUI storage directory exists. NiceGUI resolves
+    # the actual storage location from NICEGUI_STORAGE_PATH at import time (set
+    # by entrypoint.sh to STATE_DIR/.nicegui); assigning app.storage.path here
+    # does not relocate the file store, so the env var is the real control.
     state_dir = app_config.settings.state_dir or app_config.settings.cache_dir
     storage_path = state_dir / ".nicegui"
     storage_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Follow-up to #209. Enabling GUI login uses `app.storage.user`, which NiceGUI persists to a file store under a path resolved from `NICEGUI_STORAGE_PATH` at import time (default `./.nicegui` under `/app`). The non-root container user can't create that directory, so login sessions failed to persist (`PermissionError: /app/.nicegui`, observed in prod once auth was enabled).

- `entrypoint.sh` now defaults `NICEGUI_STORAGE_PATH` to `${STATE_DIR}/.nicegui` (respecting an explicit override), so the image is correct by default for any deployment.
- `gui/app.py` documents that the env var — not the `app.storage.path` assignment — is what actually relocates the store.

Prod is already patched via an explicit `NICEGUI_STORAGE_PATH` in the HelmRelease; this makes the image self-sufficient so that env override becomes belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)