### PR TITLE
chore(dependabot): back-fill target-branch onto develop, add docker ecosystem, replace broken reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner for everything in this repository.
+# Replaces the deprecated `reviewers:` key in .github/dependabot.yml --
+# in CODEOWNERS the leading @ IS required (unlike dependabot.yml, where
+# "@solen" silently never resolved to a user).
+* @solen

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 updates:
   # Python dependencies in pip
+  #
+  # NOTE: Dependabot's pip ecosystem parses pyproject.toml and requirements
+  # files ending in .txt / .in only. It does NOT read requirements.lock or
+  # requirements-dev.lock (pip-compile output) -- and requirements.lock is what
+  # the Docker image installs. Re-run pip-compile whenever a PR here bumps
+  # requirements.txt, or the shipped image keeps the old versions.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -12,8 +18,6 @@ updates:
       - "python"
       - "security"
     open-pull-requests-limit: 5
-    reviewers:
-      - "@solen"
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
@@ -30,7 +34,20 @@ updates:
       - "github-actions"
       - "security"
     open-pull-requests-limit: 5
-    reviewers:
-      - "@solen"
     commit-message:
       prefix: "ci"
+
+  # Docker base image (Dockerfile: FROM python:3.12-slim-bookworm)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "docker"
+      - "security"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docker"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "daily"
       time: "09:00"
+    target-branch: "develop"
     labels:
       - "dependencies"
       - "python"
@@ -23,6 +24,7 @@ updates:
     schedule:
       interval: "daily"
       time: "09:00"
+    target-branch: "develop"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## The regression this prevents

`target-branch: "develop"` was committed straight to `main` in e2d56e6 and **never merged back into `develop`**. `develop`'s copy of `.github/dependabot.yml` still has no `target-branch` at all.

That means the next `develop` → `main` release merge would have overwritten main's config with develop's, silently reverting the fix and sending Dependabot PRs back to `main` — the exact problem that prompted this. This branch back-fills e2d56e6 onto `develop` so the two agree.

## Also in here

**Added the missing `docker` ecosystem.** The Dockerfile pins `FROM python:3.12-slim-bookworm`, but there was no `docker` entry, so base-image updates were never proposed — `git log --all --author=dependabot -- Dockerfile` returns zero commits. Targets `develop` like the others.

**Removed `reviewers: ["@solen"]`**, which was defective twice over:
1. The field expects a bare username. The `@` prefix is not stripped, so `"@solen"` never resolved to a user — it silently requested no review, with no error on the PR or in the Dependabot log.
2. GitHub has deprecated `reviewers`/`assignees` in `dependabot.yml` in favour of CODEOWNERS.

Replaced with `.github/CODEOWNERS` containing `* @solen`, where the leading `@` **is** required. That restores the intended review request across all three ecosystems.

Also documented in a comment that Dependabot's pip ecosystem cannot see `requirements.lock` (it parses `.txt`/`.in` and `pyproject.toml` only) — the gap PR #225 addresses.

## Heads-up on timing

Dependabot reads `dependabot.yml` from the **default branch only**. On `develop` these changes sit inert; they take effect when `develop` next merges into `main`. Until then, no docker base-image PRs and no CODEOWNERS review requests. (Cherry-picking just the config onto `main` would activate it immediately, if you'd rather not wait for the next release.)

## Verified

- Parses as valid YAML; all three ecosystems assert `target-branch == "develop"` and no `reviewers` key remains.
- `Dockerfile` confirmed to have exactly one `FROM` worth tracking.
- No `.github/CODEOWNERS` existed anywhere before this.

Note Dependabot will start offering `python` minor bumps (3.13/3.14) and `bookworm` → `trixie`. Since `pyproject.toml` sets `requires-python = ">=3.12"` and ruff targets `py312`, add an `ignore` for `version-update:semver-minor` on the docker entry if you want patch/OS-level base updates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)